### PR TITLE
chore: add adr log

### DIFF
--- a/.adrgen.toml
+++ b/.adrgen.toml
@@ -1,0 +1,6 @@
+default_meta = []
+default_status = 'accepted'
+directory = 'docs/adrs'
+id_digit_number = 3
+supported_statuses = ['accepted', 'superseded', 'amended', 'deprecated']
+template_file = 'docs/adrs/_template.md'

--- a/docs/adrs/_template.md
+++ b/docs/adrs/_template.md
@@ -1,0 +1,19 @@
+# {title}
+
+Date: {date}
+
+## Status
+
+{status}
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?

--- a/flake.lock
+++ b/flake.lock
@@ -87,16 +87,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692463654,
-        "narHash": "sha256-F8hZmsQINI+S6UROM4jyxAMbQLtzE44pI8Nk6NtMdao=",
+        "lastModified": 1702031753,
+        "narHash": "sha256-HCcfV+V6eVN5jQQgGpcEcglhU8GwO3YN4GxWQIlX+U0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ca3c9ac9f4cdd4bea19f592b32bb59b74ab7d783",
+        "rev": "e419907f36ef908ccc653cc3ceaa2ee23b61eb6c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "refs/pull/272863/head",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A unified NixOS tooling replacement for nixos-* utilities";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=refs/pull/272863/head";
 
     flake-parts.url = "github:hercules-ci/flake-parts";
 
@@ -84,6 +84,20 @@
           packages = [
             pkgs.alejandra
             pkgs.zls
+            (pkgs.adrgen.overrideAttrs (o: {
+              patches = [
+                (pkgs.fetchpatch {
+                  url = "https://github.com/asiermarques/adrgen/compare/main...blaggacao:adrgen:nixpkgs-patch/allow-override-config-file-name.patch";
+                  hash = "sha256-rJK/6wDCPpDSmxir2Rtg8GEUnXtPuPE+GcFsiqcjxZA=";
+                })
+              ];
+              ldflags =
+                o.ldflags
+                ++ [
+                  "-X github.com/asiermarques/adrgen/internal/config.FILENAME=.adrgen"
+                  "-X github.com/asiermarques/adrgen/internal/config.FORMAT=toml"
+                ];
+            }))
           ];
           nativeBuildInputs = [
             zigPackage


### PR DESCRIPTION
- We're not really in a hurry
- Undraft after:
  - isReleased: https://github.com/asiermarques/adrgen/pull/16
  - that release is updated in nixpkgs-unstable
  - local look-ahead patches are reverted
