### PR TITLE
feat: create libnix bindings from experimenal Nix C bindings

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -62,6 +62,12 @@ pub fn build(b: *std.build.Builder) void {
     options.addOption([]const u8, "git_rev", git_rev);
     exe.addOptions("options", options);
 
+    // Link to the Nix C API directly.
+    exe.linkLibC();
+    exe.linkSystemLibrary("nixexprc");
+    exe.linkSystemLibrary("nixstorec");
+    exe.linkSystemLibrary("nixutilc");
+
     const run = b.addRunArtifact(exe);
     run.step.dependOn(b.getInstallStep());
     if (b.args) |args| {

--- a/build.zig
+++ b/build.zig
@@ -16,6 +16,10 @@ pub fn build(b: *std.build.Builder) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    const libnix = b.addModule("libnix", .{
+        .source_file = .{ .path = "src/nix/lib.zig" },
+    });
+
     const exe = b.addExecutable(.{
         .name = "nixos",
         .root_source_file = .{ .path = "src/main.zig" },
@@ -23,6 +27,7 @@ pub fn build(b: *std.build.Builder) void {
         .optimize = optimize,
     });
     b.installArtifact(exe);
+    exe.addModule("nix", libnix);
 
     const full_version = blk: {
         if (mem.endsWith(u8, version, "-dev")) {

--- a/flake.lock
+++ b/flake.lock
@@ -32,6 +32,22 @@
         "type": "github"
       }
     },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -85,18 +101,56 @@
         "type": "github"
       }
     },
+    "libgit2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1697646580,
+        "narHash": "sha256-oX4Z3S9WtJlwvj0uH9HlYcWv+x1hqp8mhXl7HsLu2f0=",
+        "owner": "libgit2",
+        "repo": "libgit2",
+        "rev": "45fd9ed7ae1a9b74b957ef4f337bc3c8b3df01b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "libgit2",
+        "repo": "libgit2",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "libgit2": "libgit2",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1702596405,
+        "narHash": "sha256-81pCrB0eWXB5RY5p7LTEwr3TigNIw8ElLrPnSBQI7mw=",
+        "owner": "tweag",
+        "repo": "nix",
+        "rev": "ced7ee30a445182530e1618b64e78c8e38e88ae5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "ref": "nix-c-bindings",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692463654,
-        "narHash": "sha256-F8hZmsQINI+S6UROM4jyxAMbQLtzE44pI8Nk6NtMdao=",
+        "lastModified": 1701355166,
+        "narHash": "sha256-4V7XMI0Gd+y0zsi++cEHd99u3GNL0xSTGRmiWKzGnUQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ca3c9ac9f4cdd4bea19f592b32bb59b74ab7d783",
+        "rev": "36c4ac09e9bebcec1fa7b7539cddb0c9e837409c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "staging-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -119,7 +173,39 @@
         "type": "github"
       }
     },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1692463654,
+        "narHash": "sha256-F8hZmsQINI+S6UROM4jyxAMbQLtzE44pI8Nk6NtMdao=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ca3c9ac9f4cdd4bea19f592b32bb59b74ab7d783",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1689088367,
         "narHash": "sha256-Y2tl2TlKCWEHrOeM9ivjCLlRAKH3qoPUE/emhZECU14=",
@@ -140,15 +226,16 @@
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs",
+        "nix": "nix",
+        "nixpkgs": "nixpkgs_2",
         "zig-overlay": "zig-overlay"
       }
     },
     "zig-overlay": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat_3",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1692490902,

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,9 @@
 
     flake-parts.url = "github:hercules-ci/flake-parts";
 
+    # Use unstable Nix C bindings
+    nix.url = "github:tweag/nix/nix-c-bindings";
+
     zig-overlay.url = "github:mitchellh/zig-overlay";
 
     flake-compat = {
@@ -37,19 +40,24 @@
         ...
       }: let
         zigPackage = inputs.zig-overlay.packages.${system}."0.11.0";
+        nixPackage = inputs.nix.packages.${system}.nix;
 
         inherit (inputs.gitignore.lib) gitignoreSource;
 
         package = {
           zig,
+          pkg-config,
+          nix,
           flake ? true,
         }:
-          pkgs.stdenvNoCC.mkDerivation {
+          pkgs.stdenv.mkDerivation {
             pname = "nixos";
             version = "0.1.0";
             src = gitignoreSource ./.;
 
-            nativeBuildInputs = [zig];
+            nativeBuildInputs = [zig pkg-config];
+
+            buildInputs = [nix];
 
             dontConfigure = true;
             dontInstall = true;
@@ -76,7 +84,10 @@
       in {
         packages = rec {
           default = nixos;
-          nixos = pkgs.callPackage package {zig = zigPackage;};
+          nixos = pkgs.callPackage package {
+            zig = zigPackage;
+            nix = nixPackage;
+          };
           nixosLegacy = nixos.override {flake = false;};
         };
 
@@ -88,6 +99,10 @@
           ];
           nativeBuildInputs = [
             zigPackage
+            pkgs.pkg-config
+          ];
+          buildInputs = [
+            nixPackage.dev
           ];
 
           ZIG_DOCS = "${zigPackage}/doc/langref.html";

--- a/src/main.zig
+++ b/src/main.zig
@@ -28,6 +28,8 @@ const App = argparse.App;
 const ArgParseError = argparse.ArgParseError;
 const Command = argparse.Command;
 
+const nix = @import("nix");
+
 const MainArgs = struct {
     subcommand: Subcommand = undefined,
 
@@ -127,6 +129,9 @@ pub fn main() !u8 {
     var arena_allocator = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena_allocator.deinit();
     const allocator = arena_allocator.allocator();
+
+    try nix.util.init();
+    log.info("libnix version: {s}", .{nix.util.version()});
 
     var argv = try std.process.argsWithAllocator(allocator);
     defer argv.deinit();

--- a/src/main.zig
+++ b/src/main.zig
@@ -130,8 +130,15 @@ pub fn main() !u8 {
     defer arena_allocator.deinit();
     const allocator = arena_allocator.allocator();
 
-    try nix.util.init();
-    log.info("libnix version: {s}", .{nix.util.version()});
+    const nix_context = nix.util.NixContext.init() catch {
+        log.err("out of memory, cannot continue", .{});
+        return 1;
+    };
+    defer nix_context.deinit();
+
+    nix.util.init(nix_context) catch unreachable;
+    nix.store.init(nix_context) catch unreachable;
+    nix.expr.init(nix_context) catch unreachable;
 
     var argv = try std.process.argsWithAllocator(allocator);
     defer argv.deinit();

--- a/src/nix/c.zig
+++ b/src/nix/c.zig
@@ -1,0 +1,6 @@
+pub const libnix = @cImport({
+    @cInclude("nix/nix_api_util.h");
+    @cInclude("nix/nix_api_expr.h");
+    @cInclude("nix/nix_api_store.h");
+    @cInclude("nix/nix_api_value.h");
+});

--- a/src/nix/error.zig
+++ b/src/nix/error.zig
@@ -1,0 +1,22 @@
+const libutil = @cImport({
+    @cInclude("nix/nix_api_util.h");
+});
+
+pub const NixError = error{
+    Unknown,
+    Overflow,
+    Key,
+    NixError,
+};
+
+/// Convert `nix_err` code from `libutil` into Zig `NixError` type.
+/// Do not convert NIX_OK (0), as this is not an error.
+pub fn nixError(code: libutil.nix_err) NixError {
+    return switch (code) {
+        -1 => NixError.Unknown,
+        -2 => NixError.Overflow,
+        -3 => NixError.Key,
+        -4 => NixError.NixError,
+        else => unreachable,
+    };
+}

--- a/src/nix/expr.zig
+++ b/src/nix/expr.zig
@@ -1,0 +1,247 @@
+const std = @import("std");
+const mem = std.mem;
+const Allocator = mem.Allocator;
+
+const errors = @import("./error.zig");
+const nixError = errors.nixError;
+const NixError = errors.NixError;
+
+const util = @import("./util.zig");
+const NixContext = util.NixContext;
+
+const lstore = @import("./store.zig");
+const Store = lstore.Store;
+
+const libnix = @import("./c.zig").libnix;
+
+/// Initialize the Nix expression evaluator. Call this function
+/// before creating any `State`s; it can be called multiple times.
+pub fn init(context: NixContext) NixError!void {
+    const err = libnix.nix_libexpr_init(context.context);
+    if (err != 0) return nixError(err);
+}
+
+pub const EvalState = struct {
+    state: *libnix.State,
+    store: *libnix.Store,
+
+    const Self = @This();
+
+    /// Create a new Nix state. Caller must call `deinit()` to
+    /// release memory.
+    // TODO: add search path param
+    pub fn init(context: NixContext, store: Store) !Self {
+        var new_state = libnix.nix_state_create(context.context, null, store.store);
+        if (new_state == null) {
+            try context.errorCode();
+            return error.OutOfMemory;
+        }
+
+        return Self{
+            .state = new_state.?,
+            .store = store.store,
+        };
+    }
+
+    /// Allocate a Nix value. Owned by the GC; use
+    /// `gc.deref` when finished with this value.
+    pub fn createValue(self: Self, context: NixContext) !Value {
+        var new_value = libnix.nix_alloc_value(context.context, self.state);
+        if (new_value == null) {
+            try context.errorCode();
+            return error.OutOfMemory;
+        }
+
+        return Value{
+            .value = new_value.?,
+            .state = self.state,
+        };
+    }
+
+    /// Parse and evaluates a Nix expression from a string.
+    pub fn evalFromString(self: Self, allocator: Allocator, context: NixContext, expr: []const u8, path: []const u8, value: Value) !void {
+        const exprZ = try allocator.dupeZ(u8, expr);
+        defer allocator.free(exprZ);
+
+        const pathZ = try allocator.dupeZ(u8, path);
+        defer allocator.free(pathZ);
+
+        const err = libnix.nix_expr_eval_from_string(context.context, self.state, expr.ptr, path.ptr, value.value);
+        if (err != 0) return nixError(err);
+    }
+
+    /// Free this `NixState`. Does not fail.
+    pub fn deinit(self: Self) void {
+        libnix.nix_state_free(self.state);
+    }
+};
+
+pub const ValueType = enum(u8) {
+    thunk,
+    int,
+    float,
+    bool,
+    string,
+    path,
+    null,
+    attrs,
+    list,
+    function,
+    external,
+};
+
+// TODO: find out why asserts are segfaulting instead of returning error info?
+pub const Value = struct {
+    value: *libnix.Value,
+    state: *libnix.State,
+
+    const Self = @This();
+
+    /// Get a 64-bit integer value.
+    pub fn int(self: Self, context: NixContext) !i64 {
+        const result = libnix.nix_get_int(context.context, self.value);
+        try context.errorCode();
+        return result;
+    }
+
+    /// Get a 64-bit floating-point value.
+    pub fn float(self: Self, context: NixContext) !f64 {
+        const result = libnix.nix_get_float(context.context, self.value);
+        try context.errorCode();
+        return result;
+    }
+
+    /// Get a boolean value.
+    pub fn boolean(self: Self, context: NixContext) !bool {
+        const result = libnix.nix_get_bool(context.context, self.value);
+        try context.errorCode();
+        return result;
+    }
+
+    /// Get a string value. Caller owns returned memory.
+    pub fn string(self: Self, allocator: Allocator, context: NixContext) ![]const u8 {
+        const result = libnix.nix_get_string(context.context, self.value);
+        if (result) |value| {
+            return allocator.dupe(u8, mem.sliceTo(value, 0));
+        }
+        try context.errorCode();
+        unreachable;
+    }
+
+    /// Get a path value as a string. Caller owns returned memory.
+    pub fn pathString(self: Self, allocator: Allocator, context: NixContext) ![]const u8 {
+        const result = libnix.nix_get_path_string(context.context, self.value);
+        if (result) |value| {
+            return allocator.dupe(u8, mem.sliceTo(value, 0));
+        }
+        try context.errorCode();
+        unreachable;
+    }
+
+    /// Get the length of a list.
+    pub fn listSize(self: Self, context: NixContext) !usize {
+        const result = libnix.nix_get_list_size(context.context, self.value);
+        try context.errorCode();
+        return result;
+    }
+
+    /// Get the element of a list at index `i`. Clean this up
+    /// using `gc.decref`.
+    pub fn listAtIndex(self: Self, context: NixContext, i: usize) !Value {
+        const result = libnix.nix_get_list_byidx(context.context, self.value, self.state, @intCast(i));
+        if (result) |value| {
+            return Value{
+                .value = value,
+                .state = self.state,
+            };
+        }
+        try context.errorCode();
+        unreachable;
+    }
+
+    /// Get the type of this value.
+    pub fn valueType(self: Self, context: NixContext) ValueType {
+        const result = libnix.nix_get_type(context.context, self.value);
+        return @enumFromInt(result);
+    }
+
+    /// Get the type name of this value as defined in the evaluator.
+    /// Caller owns returned memory.
+    pub fn typeName(self: Self, context: NixContext) ![]const u8 {
+        const result = libnix.nix_get_typename(context.context, self.value);
+        try context.errorCode();
+        return mem.sliceTo(result, 0);
+    }
+
+    /// Set a value. Accepted types are:
+    ///  - int
+    ///  - float
+    ///  - bool
+    ///  - string
+    ///  - path
+    ///  - null
+    ///  - list
+    ///
+    /// This function takes a sentinel-terminated slice, rather than
+    /// a normal slice, in order to avoid passing in an allocator.
+    /// Lists are not type-checked for their value.
+    pub fn set(self: Self, comptime T: ValueType, context: NixContext, value: (switch (T) {
+        .int => i64,
+        .float => f64,
+        .bool => bool,
+        .string, .path => [:0]const u8,
+        .null => @TypeOf(null),
+        .list => Value,
+        else => @compileError("type '" ++ @tagName(T) ++ "' cannot be used for the set method"),
+    })) !void {
+        const err = switch (T) {
+            .int => libnix.nix_set_int(context.context, self.value, value),
+            .float => libnix.nix_set_float(context.context, self.value, value),
+            .bool => libnix.nix_set_bool(context.context, self.value, value),
+            .string => libnix.nix_set_string(context.context, self.value, value),
+            // TODO: setting a path hangs for some reason.
+            .path => libnix.nix_set_path_string(context.context, self.value, value),
+            .null => libnix.nix_set_null(context.context, self.value),
+            else => @panic("value cannot be of type " ++ @typeName(@TypeOf(value))),
+        };
+        if (err != 0) return nixError(err);
+    }
+
+    /// Manipulate a list by index. Don't do this mid-computation.
+    pub fn setListIndex(self: Self, context: NixContext, index: usize, value: Value) !void {
+        const err = libnix.nix_set_list_byidx(context.context, self.value, @intCast(index), value.value);
+        if (err != 0) return nixError(err);
+    }
+
+    // TODO: make a toOwnedSlice method for stringifying a value.
+};
+
+pub const gc = struct {
+    /// Trigger the garbage collector manually.
+    /// Useful for debugging.
+    pub fn trigger() void {
+        libnix.nix_gc_now();
+    }
+
+    /// Increment the garbage collector reference counter for the given object
+    pub fn incRef(comptime T: type, context: NixContext, object: T) NixError!void {
+        if (T == Value) {
+            const err = libnix.nix_gc_incref(context.context, object.value);
+            if (err != 0) return nixError(err);
+        }
+
+        // TODO: are there any more value types to handle?
+        @compileError("value to increment GC refcount on must be a valid GC-able type");
+    }
+
+    /// Decrement the garbage collector reference counter for the given object.
+    pub fn decRef(comptime T: type, context: NixContext, object: T) NixError!void {
+        if (T == Value) {
+            const err = libnix.nix_gc_decref(context.context, object.value);
+            if (err != 0) return nixError(err);
+        } else {
+            // TODO: are there any more value types to handle?
+            @compileError("value to increment GC refcount on must be a valid GC-able type");
+        }
+    }
+};

--- a/src/nix/lib.zig
+++ b/src/nix/lib.zig
@@ -1,3 +1,4 @@
 pub const util = @import("./util.zig");
 pub const store = @import("./store.zig");
+pub const expr = @import("./expr.zig");
 pub const NixError = @import("./error.zig").NixError;

--- a/src/nix/lib.zig
+++ b/src/nix/lib.zig
@@ -1,2 +1,3 @@
 pub const util = @import("./util.zig");
+pub const store = @import("./store.zig");
 pub const NixError = @import("./error.zig").NixError;

--- a/src/nix/lib.zig
+++ b/src/nix/lib.zig
@@ -1,0 +1,2 @@
+pub const util = @import("./util.zig");
+pub const NixError = @import("./error.zig").NixError;

--- a/src/nix/store.zig
+++ b/src/nix/store.zig
@@ -1,0 +1,128 @@
+const std = @import("std");
+const mem = std.mem;
+const Allocator = mem.Allocator;
+
+const util = @import("./util.zig");
+const NixContext = util.NixContext;
+
+const errors = @import("./error.zig");
+const nixError = errors.nixError;
+const NixError = errors.NixError;
+
+const libnix = @import("./c.zig").libnix;
+
+/// Initialize the Nix store library. Call this before
+/// creating a store; it can be called multiple times.
+pub fn init(context: NixContext) NixError!void {
+    const err = libnix.nix_libstore_init(context.context);
+    if (err != 0) return nixError(err);
+}
+
+/// Load plugins specified in the settings. Call this
+/// once, after calling the other init functions and setting
+/// any desired settings.
+pub fn initPlugins(context: NixContext) NixError!void {
+    const err = libnix.nix_init_plugins(context.context);
+    if (err != 0) return nixError(err);
+}
+
+pub const Store = struct {
+    store: *libnix.Store,
+
+    const Self = @This();
+
+    /// Open a Nix store. Call `unref` after to release memory.
+    pub fn open(allocator: Allocator, context: NixContext, uri: []const u8, options: anytype) !Self {
+        _ = options;
+
+        const uriZ = try allocator.dupeZ(u8, uri);
+        defer allocator.free(uriZ);
+
+        var new_store = libnix.nix_store_open(context.context, uriZ.ptr, null);
+        if (new_store == null) {
+            try context.errorCode(); // See if there was a Nix error first.
+            return error.OutOfMemory; // Otherwise, probably out of memory.
+        }
+
+        return Self{ .store = new_store.? };
+    }
+
+    /// Get the version of a Nix store. Caller owns returned memory.
+    pub fn getVersion(self: Self, allocator: Allocator, context: NixContext, max_bytes: c_uint) ![]u8 {
+        if (max_bytes < 1) @panic("nixstore: nix_store_get_version: max_bytes cannot be < 1");
+
+        var buf = try allocator.alloc(u8, @intCast(max_bytes));
+        defer allocator.free(buf);
+
+        const err = libnix.nix_store_get_version(context.context, self.store, buf.ptr, max_bytes);
+        if (err != 0) return nixError(err);
+
+        return try allocator.dupe(u8, mem.sliceTo(buf, 0));
+    }
+
+    /// Get the URI of a Nix store. Caller owns returned memory.
+    pub fn getUri(self: Self, allocator: Allocator, context: NixContext, max_bytes: c_uint) ![]u8 {
+        if (max_bytes < 1) @panic("nixstore: nix_store_get_uri: max_bytes cannot be < 1");
+
+        var buf = try allocator.alloc(u8, @intCast(max_bytes));
+        defer allocator.free(buf);
+
+        const err = libnix.nix_store_get_uri(context.context, self.store, buf.ptr, max_bytes);
+        if (err != 0) return nixError(err);
+
+        return try allocator.dupe(u8, mem.sliceTo(buf, 0));
+    }
+
+    /// Retrieve a store path from a Nix store.
+    pub fn parsePath(self: Self, allocator: Allocator, context: NixContext, path: []const u8) !StorePath {
+        const pathZ = try allocator.dupeZ(u8, path);
+        defer allocator.free(pathZ);
+
+        const store_path = libnix.nix_store_parse_path(context.context, self.store, pathZ);
+        if (store_path == null) {
+            try context.errorCode(); // See if there was a Nix error first.
+            return error.OutOfMemory; // Otherwise, probably out of memory.
+        }
+
+        return StorePath{
+            .path = store_path.?,
+            .store = self.store,
+        };
+    }
+
+    /// Unref this Nix store. Does not fail; it'll be closed and
+    /// deallocated when all references are gone.
+    pub fn unref(self: Self) void {
+        libnix.nix_store_unref(self.store);
+    }
+};
+
+pub const StorePath = struct {
+    path: *libnix.StorePath,
+    store: *libnix.Store,
+
+    const Self = @This();
+
+    /// Check if this StorePath is valid (aka if exists in the referenced
+    /// store). Error info is stored in the passed context.
+    pub fn isValid(self: Self, context: NixContext) bool {
+        const valid = libnix.nix_store_is_valid_path(context.context, self.store, self.path);
+        return valid;
+    }
+
+    /// Realize a Nix store path. This is a blocking function.
+    pub fn build(
+        self: Self,
+        context: NixContext,
+        user_data: ?*anyopaque,
+        callback: *const fn (user_data: ?*anyopaque, out_name: [*c]const u8, out: [*c]const u8) callconv(.C) void,
+    ) NixError!void {
+        const err = libnix.nix_store_build(context.context, self.store, self.path, user_data, callback);
+        if (err != 0) return nixError(err);
+    }
+
+    // Deallocate this StorePath. Does not fail.
+    pub fn deinit(self: Self) void {
+        libnix.nix_store_path_free(self.path);
+    }
+};

--- a/src/nix/util.zig
+++ b/src/nix/util.zig
@@ -1,0 +1,117 @@
+const std = @import("std");
+const mem = std.mem;
+const Allocator = mem.Allocator;
+
+const errors = @import("./error.zig");
+const nixError = errors.nixError;
+const NixError = errors.NixError;
+
+const libnix = @import("./c.zig").libnix;
+
+/// Initialize libutil and its dependencies.
+pub fn init(context: NixContext) NixError!void {
+    const err = libnix.nix_libutil_init(context.context);
+    if (err != 0) return nixError(err);
+}
+
+/// Retrieve the current libnix library version.
+pub fn version() []const u8 {
+    return mem.span(libnix.nix_version_get());
+}
+
+pub const settings = struct {
+    /// Retrieve a setting from the Nix global configuration.
+    /// Caller owns returned memory.
+    pub fn get(allocator: Allocator, context: NixContext, key: []const u8, max_bytes: c_int) ![]u8 {
+        if (max_bytes < 1) @panic("nixutil: nix_setting_get: max_bytes cannot be < 1");
+
+        var buf = try allocator.alloc(u8, @intCast(max_bytes));
+        defer allocator.free(buf);
+
+        const keyz = try allocator.dupeZ(u8, key);
+        defer allocator.free(keyz);
+
+        const err = libnix.nix_setting_get(context.context, keyz.ptr, buf.ptr, max_bytes);
+        if (err != 0) return nixError(err);
+
+        return try allocator.dupe(u8, mem.sliceTo(buf, 0));
+    }
+
+    /// Set a setting in the Nix global configuration.
+    pub fn set(allocator: Allocator, context: NixContext, key: []const u8, value: []const u8) !void {
+        const keyz = try allocator.dupeZ(u8, key);
+        defer allocator.free(keyz);
+
+        const valuez = try allocator.dupeZ(u8, value);
+        defer allocator.free(valuez);
+
+        const err = libnix.nix_setting_set(context.context, keyz.ptr, valuez.ptr);
+        if (err != 0) return nixError(err);
+    }
+};
+
+pub const NixContext = struct {
+    context: *libnix.nix_c_context,
+
+    const Self = @This();
+
+    /// Create an instance of NixContext. Caller must call deinit()
+    /// to free memory with the underlying allocator.
+    pub fn init() !Self {
+        var new_context = libnix.nix_c_context_create();
+        if (new_context == null) return error.OutOfMemory;
+
+        return Self{
+            .context = new_context.?,
+        };
+    }
+
+    /// Retrieve the most recent error code from this context.
+    pub fn errorCode(self: Self) NixError!void {
+        const err = libnix.nix_err_code(self.context);
+        if (err != 0) return nixError(err);
+    }
+
+    /// Retrieve the error message from errorInfo inside another context.
+    /// Used to inspect Nix error messages; only call after the previous
+    /// Nix function has returned `NixError.NixError`. Caller owns returned
+    /// memory.
+    pub fn errorInfoMessage(self: Self, allocator: Allocator, context: NixContext, max_bytes: c_int) ![]u8 {
+        if (max_bytes < 1) @panic("nixutil: nix_err_info_msg: max_bytes cannot be < 1");
+
+        const buf = try allocator.alloc(u8, @intCast(max_bytes));
+        defer allocator.free(buf);
+
+        const err = libnix.nix_err_info_msg(context.context, self.context, buf.ptr, max_bytes);
+        if (err != 0) return nixError(err);
+
+        return try allocator.dupe(u8, mem.sliceTo(buf, 0));
+    }
+
+    /// Retrieve the most recent error message directly from a context.
+    /// Caller does not own returned memory.
+    pub fn errorMessage(self: Self, context: NixContext) !?[]const u8 {
+        const message = libnix.nix_err_msg(context.context, self.context, null);
+        return if (message) |m| mem.span(m) else null;
+    }
+
+    /// Retrieve the error name from a context. Used to inspect Nix error
+    /// messages; only call after the previous Nix function has returned
+    /// `NixError.NixError`. Caller owns returned memory.
+    pub fn errorName(self: Self, allocator: Allocator, context: NixContext, max_bytes: c_int) ![]u8 {
+        if (max_bytes < 1) @panic("nixutil: nix_err_name: max_bytes cannot be < 1");
+
+        const buf = try allocator.alloc(u8, @intCast(max_bytes));
+        errdefer allocator.free(buf);
+
+        const err = libnix.nix_err_name(context.context, self.context, buf.ptr, max_bytes);
+        if (err != 0) return nixError(err);
+
+        return try allocator.dupe(u8, mem.sliceTo(buf, 0));
+    }
+
+    /// Free the `NixContext`. Does not fail.
+    pub fn deinit(self: Self) void {
+        libnix.nix_c_context_free(self.context);
+    }
+};


### PR DESCRIPTION
This creates some idiomatic Zig bindings for the experimental C API. I want to use this for evaluating some Nix stuff without having access to the Nix command all the time, and this could be useful for bootstrapping NixOS with a static executable in the future, which could be fun! Who knows.