### PR TITLE
feat(config): replace JSON config with TOML

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,48 @@ the recommended way to use this program.
 ## Configuration
 
 This can be configured using the NixOS module (the preferred way), which
-generates a file at `/etc/nixos-cli/config.json`. I would prefer using TOML at
-some point, but for right now JSON is the file format I can get up and running
-with the fastest.
+generates a file at `/etc/nixos-cli/config.toml`.
+
+The default configuration with all available options and examples is as follows:
+
+```toml
+# Aliases for long commands that you don't want to type out. All arguments
+# after the aliases are passed as-is to the underlying command.
+[[aliases]]
+# alias = "genlist" # Name of the alias; must not contain spaces
+# resolve = ["generation", "list"] # Args to resolve this alias, as a list of strings
+
+# Multiple aliases must be defined separately (this is a limitation of the
+# TOML parsing library and will be fixed in the future)
+# [[aliases]]
+# alias = "switch"
+# resolve = ["generation", "switch"]
+
+# Configuration for the `apply` subcommand.
+[apply]
+specialisation = "" # Name of specialisation to use by default
+config_location = "/etc/nixos" # Where to look for configuration by default
+
+# Configuration for the `enter` subcommand.
+[enter]
+mount_resolv_conf = true # Bind-mount the host `resolv.conf` inside the chroot for internet access
+
+# Configuration for the `init` subcommand. This is managed by `nixpkgs`, and
+# normally should not be touched unless you know what you are doing.
+[init]
+enable_xserver = false # Generate options to enable X11 display server
+desktop_config = "" # Configuration options for a desktop environment to include by default
+extra_config = "" # Extra configuration to append to `configuration.nix` as a string
+
+# Extra configuration to append to `configuration.nix`, as structured key-value pairs
+[[init.extra_attrs]]
+# name = "" # Name of key
+# value = "" # Name of value
+```
+
+Some of the configuration is a little awkward to specify right now, such
+as aliases, but I plan to fix that in the future once I can find a TOML
+parsing library that supports dynamic key-value pairs.
 
 ## TODO
 
@@ -52,17 +91,6 @@ with the fastest.
 
 - ➖ `apply`
 - ❌ `container`
-  - ❌ `list`
-  - ❌ `create <name>`
-  - ❌ `destroy <name>`
-  - ❌ `start <name>`
-  - ❌ `stop <name>`
-  - ❌ `status <name>`
-  - ❌ `update <name>`
-  - ❌ `login <name>`
-  - ❌ `run <name> <args...>`
-  - ❌ `show-ip <name>`
-  - ❌ `show-host-key <name>`
 - ✅ `enter`
 - ✅ `info`
 - ✅ `init`

--- a/build.zig
+++ b/build.zig
@@ -20,6 +20,10 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    const toml_package = b.dependency("zig-toml", .{
+        .target = target,
+        .optimize = optimize,
+    });
 
     const exe = b.addExecutable(.{
         .name = "nixos",
@@ -29,6 +33,7 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(exe);
     exe.root_module.addImport("nix", zignix_package.module("zignix"));
+    exe.root_module.addImport("toml", toml_package.module("zig-toml"));
 
     const full_version = blk: {
         if (mem.endsWith(u8, version, "-dev")) {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -11,5 +11,9 @@
             .url = "https://github.com/water-sucks/zignix/archive/31c699f40892ea0ffb144bd8513ae75755a8f0bf.tar.gz",
             .hash = "12209ebe56e52b20466a2b2d763b6195134d82544ad4decb630eb7c1e2403aff482c",
         },
+        .@"zig-toml" = .{
+            .url = "https://github.com/sam701/zig-toml/archive/d55987673c6f41931fdd6986892c3a8d7e9595a2.tar.gz",
+            .hash = "1220a982de60b7b9671df3855bd4301560476ce82c601b5c234015bbc163153db9d8",
+        },
     },
 }

--- a/deps.nix
+++ b/deps.nix
@@ -10,4 +10,11 @@ linkFarm "zig-packages" [
       hash = "sha256-Io9ZWYb+SamNzjeUWAHuBxhJZXu4TksNjMnKUAOFSHI=";
     };
   }
+  {
+    name = "1220a982de60b7b9671df3855bd4301560476ce82c601b5c234015bbc163153db9d8";
+    path = fetchzip {
+      url = "https://github.com/sam701/zig-toml/archive/d55987673c6f41931fdd6986892c3a8d7e9595a2.tar.gz";
+      hash = "sha256-gG1B2JZV1Q1RvwU+GIAV8x711LgWbY7+y4JFqqcRZZg=";
+    };
+  }
 ]

--- a/flake.nix
+++ b/flake.nix
@@ -103,23 +103,27 @@
           nixosLegacy = nixos.override {flake = false;};
         };
 
-        devShells.default = pkgs.mkShell {
-          name = "nixos-shell";
-          packages = [
-            pkgs.alejandra
-            pkgs.zon2nix
-          ];
-          nativeBuildInputs = [
-            zigPackage
-            pkgs.pkg-config
-          ];
-          buildInputs = [
-            nixPackage.dev
-          ];
+        devShells.default = let
+          zon2nix = pkgs.zon2nix.overrideAttrs (o: {
+            patches = [./zon2nix.patch];
+          });
+        in
+          pkgs.mkShell {
+            name = "nixos-shell";
+            packages = [
+              pkgs.alejandra
+              zon2nix
+            ];
+            nativeBuildInputs = [
+              zigPackage
+              pkgs.pkg-config
+            ];
+            buildInputs = [
+              nixPackage.dev
+            ];
 
-          ZIG_DOCS = "${zigPackage}/doc/langref.html";
-          ZIG_STD_DOCS = "${zigPackage}/doc/std/index.html";
-        };
+            ZIG_DOCS = "${zigPackage}/doc/langref.html";
+          };
       };
 
       flake = {

--- a/module.nix
+++ b/module.nix
@@ -7,7 +7,7 @@ self: {
   cfg = config.services.nixos-cli;
   inherit (lib) types;
 
-  jsonFormat = pkgs.formats.json {};
+  tomlFormat = pkgs.formats.toml {};
 in {
   options.services.nixos-cli = {
     enable = lib.mkEnableOption "unified NixOS tooling replacement for nixos-* utilities";
@@ -19,9 +19,9 @@ in {
     };
 
     config = lib.mkOption {
-      type = jsonFormat.type;
+      type = tomlFormat.type;
       default = {};
-      description = "Configuration for nixos-cli, in JSON format";
+      description = "Configuration for nixos-cli, in TOML format";
       apply = prev: let
         # Inherit this from the old nixos-generate-config attrs. Easy to deal with, for now.
         desktopConfig = lib.concatStringsSep "\n" config.system.nixos-generate-config.desktopConfiguration;
@@ -41,8 +41,8 @@ in {
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [cfg.package];
 
-    environment.etc."nixos-cli/config.json".source =
-      jsonFormat.generate "nixos-cli-config.json" cfg.config;
+    environment.etc."nixos-cli/config.toml".source =
+      tomlFormat.generate "nixos-cli-config.toml" cfg.config;
 
     # Hijack system builder commands to insert a `nixos-version.json` file at the root.
     system.systemBuilderCommands = let

--- a/zon2nix.patch
+++ b/zon2nix.patch
@@ -1,0 +1,63 @@
+From 30cefd232379f0c539c0e39d32a484399af0b480 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=81lan=20Cr=C3=ADstoffer?= <acristoffers@startmail.com>
+Date: Thu, 23 Nov 2023 11:41:00 +0100
+Subject: [PATCH 1/2] fix: do not reuse the buffer in the inner loop
+
+This fixes the error where the ZLS new zon file is not properly parsed.
+---
+ src/parse.zig |  3 ++-
+ 2 files changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/src/parse.zig b/src/parse.zig
+index fda3b6e..892dec6 100644
+--- a/src/parse.zig
++++ b/src/parse.zig
+@@ -39,7 +39,8 @@ pub fn parse(alloc: Allocator, deps: *StringHashMap(Dependency), file: File) !vo
+             var has_url = false;
+             var has_hash = false;
+ 
+-            const dep_init = ast.fullStructInit(&buf, dep_idx) orelse {
++            var buf2: [2]Index = undefined;
++            const dep_init = ast.fullStructInit(&buf2, dep_idx) orelse {
+                 return error.parseError;
+             };
+ 
+
+From de23dfb87a02a8f283e2869f3becb2b0bfc6fe46 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=81lan=20Cr=C3=ADstoffer?= <acristoffers@startmail.com>
+Date: Sat, 25 Nov 2023 12:53:35 +0100
+Subject: [PATCH 2/2] fix: new zon format allows .path instead of url/hash
+
+---
+ src/parse.zig | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/parse.zig b/src/parse.zig
+index 892dec6..09f7c0d 100644
+--- a/src/parse.zig
++++ b/src/parse.zig
+@@ -38,6 +38,7 @@ pub fn parse(alloc: Allocator, deps: *StringHashMap(Dependency), file: File) !vo
+             var hash: []const u8 = undefined;
+             var has_url = false;
+             var has_hash = false;
++            var has_path = false;
+ 
+             var buf2: [2]Index = undefined;
+             const dep_init = ast.fullStructInit(&buf2, dep_idx) orelse {
+@@ -53,12 +54,14 @@ pub fn parse(alloc: Allocator, deps: *StringHashMap(Dependency), file: File) !vo
+                 } else if (mem.eql(u8, name, "hash")) {
+                     hash = try parseString(alloc, ast, dep_field_idx);
+                     has_hash = true;
++                } else if (mem.eql(u8, name, "path")) {
++                    has_path = true;
+                 }
+             }
+ 
+             if (has_url and has_hash) {
+                 _ = try deps.getOrPutValue(hash, dep);
+-            } else {
++            } else if (!has_path) {
+                 return error.parseError;
+             }
+         }
+


### PR DESCRIPTION
I've wanted to use TOML as a file format for the configuration file, rather than using JSON, since it looks cleaner to me, rather than using JSON.

Superficial? Yes. But honestly, I'm willing to be convinced any other way, if it were to come up.