### PR TITLE
feat(option): init option command

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -81,6 +81,10 @@ fn nixosExecutable(b: *Build, opts: struct {
         .target = opts.target,
         .optimize = opts.optimize,
     });
+    const zf_package = b.dependency("zf", .{
+        .target = opts.target,
+        .optimize = opts.optimize,
+    });
 
     const exe = b.addExecutable(.{
         .name = "nixos",
@@ -90,6 +94,7 @@ fn nixosExecutable(b: *Build, opts: struct {
     });
     // exe.root_module.addImport("nix", zignix_package.module("zignix"));
     exe.root_module.addImport("toml", toml_package.module("zig-toml"));
+    exe.root_module.addImport("zf", zf_package.module("zf"));
 
     exe.root_module.addOptions("options", opts.options);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -20,5 +20,9 @@
             .url = "https://github.com/sam701/zig-toml/archive/67e35c75c5d11caf398bccae39d14d7187d1a952.tar.gz",
             .hash = "1220ced9b2f6943f688ce1e20a40f143d83c4182320e4b9d30e470b010d44b356f0a",
         },
+        .zf = .{
+            .url = "https://github.com/natecraddock/zf/archive/91bc9808bebddd5e1663ffde009bf4510a45e48d.tar.gz",
+            .hash = "1220a763e0496d7dade9329044fbac181eaf7c1a1f4f51ab5e3a0a77d986615aa4e4",
+        },
     },
 }

--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1717285511,
-        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
+        "lastModified": 1719994518,
+        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
+        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718428119,
-        "narHash": "sha256-WdWDpNaq6u1IPtxtYHHWpl5BmabtpmLnMAx0RdJ/vo8=",
+        "lastModified": 1720955038,
+        "narHash": "sha256-GaliJqfFwyYxReFywxAa8orCO+EnDq2NK2F+5aSc8vo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e6cea36f83499eb4e9cd184c8a8e823296b50ad5",
+        "rev": "aa247c0c90ecf4ae7a032c54fdc21b91ca274062",
         "type": "github"
       },
       "original": {
@@ -70,14 +70,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1717284937,
-        "narHash": "sha256-lIbdfCsf8LMFloheeE6N31+BMIeixqyQWbSr2vk79EQ=",
+        "lastModified": 1719876945,
+        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
       }
     },
     "nixpkgs-lib_2": {
@@ -122,11 +122,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1718668097,
-        "narHash": "sha256-f/vqhQMb83W7KB0rOh+LUpQ5yXXUK4p11h4itzXiOAE=",
+        "lastModified": 1720999842,
+        "narHash": "sha256-9G/mlNIbamhnTs1VGB0RlU+JcJGHw5bN0D9BcnQf+DM=",
         "owner": "water-sucks",
         "repo": "zig-deps-fod",
-        "rev": "bdc339b597161e396aac063c26d538197bdfcdb6",
+        "rev": "f0a57cdf06f2100d7a045a4062592aeb89468868",
         "type": "github"
       },
       "original": {

--- a/package.nix
+++ b/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
       inherit stdenv zig;
       name = pname;
       src = ./.;
-      depsHash = "sha256-a4GiBgoqMzYiceDeiu4CaDXtshp6qCXhQ1pMilRvVNg=";
+      depsHash = "sha256-y2inrj4evVbE4k0u5w6PGi65GWVxcoC/QUrOyPHgbGw=";
     };
   in ''
     mkdir -p .cache

--- a/src/main.zig
+++ b/src/main.zig
@@ -17,6 +17,7 @@ const info = @import("info.zig");
 const init = @import("init.zig");
 const install = @import("install.zig");
 const manual = @import("manual.zig");
+const option = @import("option.zig");
 const repl = @import("repl.zig");
 
 const ApplyCommand = apply.ApplyCommand;
@@ -26,6 +27,7 @@ const InfoCommand = info.InfoCommand;
 const InitConfigCommand = init.InitConfigCommand;
 const InstallCommand = install.InstallCommand;
 const ReplCommand = repl.ReplCommand;
+const OptionCommand = option.OptionCommand;
 
 const config = @import("config.zig");
 
@@ -60,6 +62,7 @@ const MainArgs = struct {
         init: InitConfigCommand,
         install: InstallCommand,
         manual,
+        option: OptionCommand,
         repl: ReplCommand,
     };
 
@@ -79,6 +82,7 @@ const MainArgs = struct {
         \\    init          Initialize a configuration.nix file
         \\    install       Install a NixOS configuration and bootloader
         \\    manual        Open the NixOS manual in a browser
+        \\    option        Query NixOS options and their details
         \\    repl          Start a Nix REPL with system configuration loaded
         \\
         \\Options:
@@ -124,6 +128,8 @@ const MainArgs = struct {
                     result.subcommand = .{ .install = InstallCommand.init(allocator) };
                 } else if (mem.eql(u8, arg, "manual")) {
                     result.subcommand = .manual;
+                } else if (mem.eql(u8, arg, "option")) {
+                    result.subcommand = .{ .option = OptionCommand.init(allocator) };
                 } else if (mem.eql(u8, arg, "repl")) {
                     result.subcommand = .{ .repl = ReplCommand.init(allocator) };
                 } else {
@@ -154,7 +160,7 @@ const MainArgs = struct {
                     }
                 }
             } else {
-                argError("unknown subcommand '{s}'", .{arg});
+                argError("argument '{s}' is not valid in this context", .{arg});
                 return ArgParseError.InvalidSubcommand;
             }
 
@@ -170,6 +176,7 @@ const MainArgs = struct {
                     .init => |*sub_args| try InitConfigCommand.parseArgs(argv, sub_args),
                     .install => |*sub_args| try InstallCommand.parseArgs(argv, sub_args),
                     .manual => null,
+                    .option => |*sub_args| try OptionCommand.parseArgs(argv, sub_args),
                     .repl => |*sub_args| try ReplCommand.parseArgs(argv, sub_args),
                 };
             } else {
@@ -193,6 +200,7 @@ const MainArgs = struct {
                 .enter => |*args| args.deinit(),
                 .install => |*args| args.deinit(),
                 .repl => |*args| args.deinit(),
+                .option => |*args| args.deinit(),
                 else => {},
             }
         }
@@ -269,6 +277,7 @@ pub fn main() !u8 {
         .init => |args| init.initConfigMain(allocator, args),
         .install => |args| install.installMain(allocator, args),
         .manual => manual.manualMain(allocator),
+        .option => |args| option.optionMain(allocator, args),
         .repl => |args| repl.replMain(allocator, args),
     };
 

--- a/src/option.zig
+++ b/src/option.zig
@@ -199,10 +199,13 @@ const UNDERLINE = "\x1B[4m";
 fn displayOption(name: []const u8, opt: NixosOptionFromFile) void {
     const stdout = io.getStdOut().writer();
 
+    // Descriptions more often than not have lots of newlines and spaces,
+    // especially trailing ones. This should be trimmed.
+    const description = mem.trim(u8, opt.description, "\n ");
     const default = if (opt.default) |d| d.text else null;
 
     println(stdout, BOLD ++ "Name\n" ++ RESET ++ "{s}\n", .{name});
-    println(stdout, BOLD ++ "Description\n" ++ RESET ++ "{s}\n", .{opt.description});
+    println(stdout, BOLD ++ "Description\n" ++ RESET ++ "{s}\n", .{description});
     println(stdout, BOLD ++ "Type\n" ++ RESET ++ "{s}\n", .{opt.type});
     println(stdout, BOLD ++ "Default\n" ++ RESET ++ "{s}\n", .{default orelse "No default value."});
     if (opt.example) |example| {
@@ -255,7 +258,7 @@ fn option(allocator: Allocator, args: OptionCommand) !void {
             if (args.json) {
                 const output = .{
                     .name = key,
-                    .description = value.description,
+                    .description = mem.trim(u8, value.description, "\n "),
                     .type = value.type,
                     .default = if (value.default) |d| d.text else null,
                     .example = if (value.example) |e| e.text else null,

--- a/src/option.zig
+++ b/src/option.zig
@@ -1,0 +1,291 @@
+const std = @import("std");
+const opts = @import("options");
+const fmt = std.fmt;
+const fs = std.fs;
+const io = std.io;
+const json = std.json;
+const mem = std.mem;
+const posix = std.posix;
+const Allocator = mem.Allocator;
+const ArrayList = std.ArrayList;
+const ArgIterator = std.process.ArgIterator;
+
+const argparse = @import("argparse.zig");
+const ArgParseError = argparse.ArgParseError;
+const argIs = argparse.argIs;
+const argError = argparse.argError;
+const getNextArgs = argparse.getNextArgs;
+
+const Constants = @import("constants.zig");
+
+const log = @import("log.zig");
+
+const utils = @import("utils.zig");
+const FlakeRef = utils.FlakeRef;
+const fileExistsAbsolute = utils.fileExistsAbsolute;
+const runCmd = utils.runCmd;
+const println = utils.println;
+
+pub const OptionError = error{
+    NoOptionCache,
+    NoResultFound,
+    UnsupportedOs,
+};
+
+pub const OptionCommand = struct {
+    option: ?[]const u8 = null,
+    json: bool = false,
+    interactive: bool = false,
+    includes: ArrayList([]const u8),
+
+    const Self = @This();
+
+    const usage =
+        \\Query available NixOS module options for this system.
+        \\
+        \\Usage:
+        \\    nixos option [NAME] [options]
+        \\
+        \\Arguments:
+        \\    [NAME]    Name of option to use. Not required in interactive mode.
+        \\
+        \\Options:
+        \\    -h, --help              Show this help menu
+        \\    -i, --interactive       Show interactive search bar for options
+        \\    -I, --include <PATH>    Add a path value to the Nix search path
+        \\    -j, --json              Output option information in JSON format
+        \\
+    ;
+
+    pub fn init(allocator: Allocator) Self {
+        return OptionCommand{
+            .includes = ArrayList([]const u8).init(allocator),
+        };
+    }
+
+    pub fn parseArgs(argv: *ArgIterator, parsed: *OptionCommand) !?[]const u8 {
+        var next_arg = argv.next();
+        while (next_arg) |arg| {
+            if (argIs(arg, "--help", "-h")) {
+                log.print(usage, .{});
+                return ArgParseError.HelpInvoked;
+            } else if (argIs(arg, "--interactive", "-i")) {
+                parsed.interactive = true;
+            } else if (argIs(arg, "--include", "-I")) {
+                const next = (try getNextArgs(argv, arg, 1))[0];
+                try parsed.includes.append(next);
+            } else if (argIs(arg, "--json", "-j")) {
+                parsed.json = true;
+            } else {
+                if (parsed.option == null) {
+                    parsed.option = arg;
+                } else {
+                    return arg;
+                }
+            }
+
+            next_arg = argv.next();
+        }
+
+        if (parsed.interactive and parsed.json) {
+            argError("--interactive and --json flags conflict", .{});
+            return ArgParseError.ConflictingOptions;
+        }
+
+        if (!parsed.interactive and parsed.option == null) {
+            argError("missing required argument <NAME>", .{});
+            return ArgParseError.MissingRequiredArgument;
+        }
+
+        return null;
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.includes.deinit();
+    }
+};
+
+const NixosOptionFromFile = struct {
+    description: []const u8,
+    type: []const u8,
+    default: ?struct {
+        _type: []const u8,
+        text: []const u8,
+    } = null,
+    example: ?struct {
+        _type: []const u8,
+        text: []const u8,
+    } = null,
+    loc: []const []const u8,
+    readOnly: bool,
+    declarations: []const []const u8,
+};
+
+fn findNixosOptionFilepathLegacy(allocator: Allocator) ![]const u8 {
+    const argv = &.{ "nix-build", "<nixpkgs/nixos>", "--no-out-link", "-A", "config.system.build.manual.optionsJSON" };
+
+    const result = runCmd(.{
+        .allocator = allocator,
+        .argv = argv,
+        .stderr_type = .Ignore,
+    }) catch return OptionError.NoOptionCache;
+
+    if (result.status != 0) {
+        log.err("unable to find options cache; cannot continue", .{});
+        return OptionError.NoOptionCache;
+    }
+    defer allocator.free(result.stdout.?);
+
+    return try allocator.dupe(u8, result.stdout.?);
+}
+
+fn findNixosOptionFilepathFlake(allocator: Allocator) ![]const u8 {
+    var hostname_buf: [posix.HOST_NAME_MAX]u8 = undefined;
+    var flake_ref = utils.findFlakeRef() catch return OptionError.NoOptionCache;
+    flake_ref.inferSystemNameIfNeeded(&hostname_buf) catch return OptionError.NoOptionCache;
+
+    const option_attr = try fmt.allocPrint(allocator, "{s}#nixosConfigurations.{s}.config.system.build.manual.optionsJSON", .{
+        flake_ref.uri,
+        flake_ref.system,
+    });
+    defer allocator.free(option_attr);
+
+    const argv = &.{ "nix", "build", "--print-out-paths", option_attr };
+
+    const result = runCmd(.{
+        .allocator = allocator,
+        .argv = argv,
+        .stderr_type = .Ignore,
+    }) catch return OptionError.NoOptionCache;
+
+    if (result.status != 0) {
+        log.err("unable to find options cache; cannot continue", .{});
+        return OptionError.NoOptionCache;
+    }
+    defer allocator.free(result.stdout.?);
+
+    return try allocator.dupe(u8, result.stdout.?);
+}
+
+fn loadOptionsFromFile(allocator: Allocator, filename: []const u8) !json.Parsed(json.ArrayHashMap(NixosOptionFromFile)) {
+    var file = fs.openFileAbsolute(filename, .{}) catch |err| {
+        log.err("cannot open options cache file at {s}: {s}", .{ filename, @errorName(err) });
+        return err;
+    };
+    defer file.close();
+
+    var buffered_reader = io.bufferedReader(file.reader());
+
+    var json_reader = std.json.reader(allocator, buffered_reader.reader());
+    defer json_reader.deinit();
+
+    const parsed = std.json.parseFromTokenSource(json.ArrayHashMap(NixosOptionFromFile), allocator, &json_reader, .{
+        .ignore_unknown_fields = true,
+        .duplicate_field_behavior = .use_last,
+    }) catch |err| {
+        log.err("unable to parse options cache file at {s}: {s}", .{ filename, @errorName(err) });
+        return err;
+    };
+
+    return parsed;
+}
+
+const RESET = "\x1B[0m";
+const BOLD = "\x1B[1m";
+const ITALIC = "\x1B[3m";
+const UNDERLINE = "\x1B[4m";
+
+fn displayOption(name: []const u8, opt: NixosOptionFromFile) void {
+    const stdout = io.getStdOut().writer();
+
+    const default = if (opt.default) |d| d.text else null;
+
+    println(stdout, BOLD ++ "Name\n" ++ RESET ++ "{s}\n", .{name});
+    println(stdout, BOLD ++ "Description\n" ++ RESET ++ "{s}\n", .{opt.description});
+    println(stdout, BOLD ++ "Type\n" ++ RESET ++ "{s}\n", .{opt.type});
+    println(stdout, BOLD ++ "Default\n" ++ RESET ++ "{s}\n", .{default orelse "No default value."});
+    if (opt.example) |example| {
+        println(stdout, BOLD ++ "Example\n" ++ RESET ++ "{s}\n", .{example.text});
+    }
+    println(stdout, BOLD ++ "Declared In" ++ RESET, .{});
+    for (opt.declarations) |decl| {
+        println(stdout, ITALIC ++ "  - {s}" ++ RESET, .{decl});
+    }
+    if (opt.readOnly) {
+        println(stdout, UNDERLINE ++ ITALIC ++ "\nThis option is read-only." ++ RESET, .{});
+    }
+}
+
+fn option(allocator: Allocator, args: OptionCommand) !void {
+    if (!fileExistsAbsolute(Constants.etc_nixos)) {
+        log.err("the option command is unsupported on non-NixOS systems", .{});
+        return OptionError.UnsupportedOs;
+    }
+
+    if (args.interactive) {
+        log.info("this is currently unimplemented; coming soon!", .{});
+        return;
+    }
+
+    const option_cache_realized_drv = if (opts.flake)
+        try findNixosOptionFilepathFlake(allocator)
+    else
+        try findNixosOptionFilepathLegacy(allocator);
+    defer allocator.free(option_cache_realized_drv);
+
+    const options_filename = try fs.path.join(allocator, &.{ option_cache_realized_drv, "/share/doc/nixos/options.json" });
+    defer allocator.free(options_filename);
+
+    var option_map = loadOptionsFromFile(allocator, options_filename) catch return OptionError.NoOptionCache;
+    defer option_map.deinit();
+
+    const option_name = args.option.?;
+
+    var option_iter = option_map.value.map.iterator();
+
+    const stdout = io.getStdOut().writer();
+
+    while (option_iter.next()) |kv| {
+        const key = kv.key_ptr.*;
+        const value = kv.value_ptr.*;
+
+        if (mem.eql(u8, option_name, key)) {
+            if (args.json) {
+                const output = .{
+                    .name = key,
+                    .description = value.description,
+                    .type = value.type,
+                    .default = if (value.default) |d| d.text else null,
+                    .example = if (value.example) |e| e.text else null,
+                    .declarations = value.declarations,
+                    .readOnly = value.readOnly,
+                };
+
+                json.stringify(output, .{ .whitespace = .indent_2 }, stdout) catch unreachable;
+            } else {
+                displayOption(key, value);
+            }
+            break;
+        }
+    } else {
+        if (args.json) {
+            const output = .{
+                .message = "no option matching this name found",
+            };
+            json.stringify(output, .{ .whitespace = .indent_2 }, stdout) catch unreachable;
+        } else {
+            log.print("no option for query '{s}' found", .{option_name});
+        }
+        // TODO; find related options
+        return OptionError.NoResultFound;
+    }
+}
+
+pub fn optionMain(allocator: Allocator, args: OptionCommand) u8 {
+    option(allocator, args) catch |err| switch (err) {
+        OptionError.UnsupportedOs => return 3,
+        else => return 1,
+    };
+
+    return 0;
+}

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -36,7 +36,7 @@ pub const ReplCommand = struct {
         \\
         \\Usage:
         \\
-    (if (opts.flake)
+    ++ (if (opts.flake)
         \\    nixos repl [FLAKE-REF] [options]
         \\
         \\Arguments:
@@ -63,6 +63,9 @@ pub const ReplCommand = struct {
             if (argIs(arg, "--include", "-I")) {
                 const next = (try getNextArgs(argv, arg, 1))[0];
                 try parsed.includes.append(next);
+            } else if (argIs(arg, "--help", "-h")) {
+                log.print(usage, .{});
+                return ArgParseError.HelpInvoked;
             } else {
                 if (opts.flake and parsed.flake == null) {
                     parsed.flake = arg;

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -379,3 +379,5 @@ pub fn verifyLegacyConfigurationExists(allocator: Allocator, verbose: bool) !voi
         }
     }
 }
+
+pub const search = @import("utils/search.zig");

--- a/src/utils/search.zig
+++ b/src/utils/search.zig
@@ -1,0 +1,52 @@
+const std = @import("std");
+const zf = @import("zf");
+
+pub const Candidate = struct {
+    str: []const u8,
+    rank: f64 = 0,
+};
+
+pub fn rankCandidates(
+    ranked: []Candidate,
+    candidates: []const []const u8,
+    tokens: []const []const u8,
+    keep_order: bool,
+    plain: bool,
+    case_sensitive: bool,
+) []Candidate {
+    if (tokens.len == 0) {
+        for (candidates, 0..) |candidate, index| {
+            ranked[index] = .{ .str = candidate };
+        }
+        return ranked;
+    }
+
+    var index: usize = 0;
+    for (candidates) |candidate| {
+        if (zf.rank(candidate, tokens, case_sensitive, plain)) |rank| {
+            ranked[index] = .{ .str = candidate, .rank = rank };
+            index += 1;
+        }
+    }
+
+    if (!keep_order) {
+        std.sort.block(Candidate, ranked[0..index], {}, sortCandidates);
+    }
+
+    return ranked[0..index];
+}
+
+fn sortCandidates(_: void, a: Candidate, b: Candidate) bool {
+    if (a.rank < b.rank) return true;
+    if (a.rank > b.rank) return false;
+
+    if (a.str.len < b.str.len) return true;
+    if (a.str.len > b.str.len) return false;
+
+    for (a.str, 0..) |c, i| {
+        if (c < b.str[i]) return true;
+        if (c > b.str[i]) return false;
+    }
+
+    return false;
+}


### PR DESCRIPTION
This begins to implement the `option` subcommand in order to query available options without having to go to https://search.nixos.org or root through `man 5 configuration.nix` manually using `/`.

This PR only implements the beginnings (and will be mostly 1:1 with the current implementation of `nixos-option`). Later on I will bring in an interactive interface, which will make searching through options much easier.