### PR TITLE
fix: parse command-line option values correctly

### DIFF
--- a/src/argparse.zig
+++ b/src/argparse.zig
@@ -61,7 +61,7 @@ pub fn isFlag(arg: []const u8) bool {
 
 /// Get additional arguments for a flag or error out if
 /// they are not adequately provided.
-pub fn getNextArgs(args: *ArgIterator, name: []const u8, comptime amount: usize) ![]const []const u8 {
+pub inline fn getNextArgs(args: *ArgIterator, name: []const u8, comptime amount: usize) ![]const []const u8 {
     var collected_args: [amount][]const u8 = undefined;
 
     var i: usize = 0;


### PR DESCRIPTION
In `ReleaseSafe` mode, there was detectable illegal behavior that was getting triggered when options were passed to certain values grabbed with `argparse.getNextArgs()`; this was due to returning an stack-allocated array. This was not behavior that could be replicated in debug mode.

Similar problems were also resolved in the `enter` subcommand as a result of this.