### PR TITLE
feat(generation): add interactive generation management

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -86,6 +86,7 @@ fn nixosExecutable(b: *Build, opts: struct {
     const toml_package = b.dependency("zig-toml", common_dep_options);
     const zf_package = b.dependency("zf", common_dep_options);
     const zeit_package = b.dependency("zeit", common_dep_options);
+    const vaxis_package = b.dependency("vaxis", common_dep_options);
 
     const exe = b.addExecutable(.{
         .name = "nixos",
@@ -97,6 +98,7 @@ fn nixosExecutable(b: *Build, opts: struct {
     exe.root_module.addImport("toml", toml_package.module("zig-toml"));
     exe.root_module.addImport("zf", zf_package.module("zf"));
     exe.root_module.addImport("zeit", zeit_package.module("zeit"));
+    exe.root_module.addImport("vaxis", vaxis_package.module("vaxis"));
 
     exe.root_module.addOptions("options", opts.options);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -28,5 +28,9 @@
             .url = "https://github.com/rockorager/zeit/archive/1d2dc95d73160096f84830e54b419514e41e78e8.tar.gz",
             .hash = "1220aad3a3b05b27a2453ddb68caa70a656c530f69e321cf79a89d2a9c4b2dd51640",
         },
+        .vaxis = .{
+            .url = "https://github.com/rockorager/libvaxis/archive/d36ab043caf7cbb24cae1bd0346dd6b654df0653.tar.gz",
+            .hash = "12206c252ee00b9dd0214989dfa35a6eea29ac7d65d4053817f161f4c23b6e09dd89",
+        },
     },
 }

--- a/package.nix
+++ b/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
       inherit stdenv zig;
       name = pname;
       src = ./.;
-      depsHash = "sha256-K60nZXlm/IrH1AG4tGQyqex36keHU2fu7DANyvyA68Y=";
+      depsHash = "sha256-u1J43hMWFZaN9MSMfEhjOZEGFxPGUuJgnuedeZYgk6s=";
     };
   in ''
     mkdir -p .cache

--- a/src/generation/delete.zig
+++ b/src/generation/delete.zig
@@ -485,20 +485,12 @@ pub fn generationDelete(allocator: Allocator, args: GenerationDeleteCommand, pro
     log.print("There will be {d} generations left on this machine.\n", .{remaining_number_of_generations});
 
     if (!args.yes) {
-        // This large buffer is to prevent users from seeing an error if they
-        // make an extremely large typo. People who are trying to buffer overflow
-        // are in for the error message though!
-        var input_buf: [100]u8 = undefined;
-        const stdin = io.getStdIn().reader();
-
-        log.print("Proceed? [y/n]: ", .{});
-        _ = stdin.readUntilDelimiter(&input_buf, '\n') catch |err| {
+        const confirm = utils.confirmationInput() catch |err| {
             log.err("unable to read stdin for confirmation: {s}", .{@errorName(err)});
             return GenerationDeleteError.ResourceAccessFailed;
         };
-
-        if (std.ascii.toLower(input_buf[0]) != 'y') {
-            log.warn("confirmation was not given, exiting", .{});
+        if (!confirm) {
+            log.warn("confirmation was not given, not proceeding", .{});
             return;
         }
     }

--- a/src/generation/delete.zig
+++ b/src/generation/delete.zig
@@ -181,7 +181,7 @@ pub const GenerationDeleteError = error{
     CommandFailed,
 } || Allocator.Error;
 
-fn printDeleteSummary(allocator: Allocator, generations: []GenerationMetadata) !void {
+pub fn printDeleteSummary(allocator: Allocator, generations: []GenerationMetadata) !void {
     log.print("The following generations will be deleted:\n\n", .{});
 
     const headers: []const []const u8 = &.{ "#", "Description", "Creation Date" };
@@ -272,7 +272,7 @@ fn printDeleteSummary(allocator: Allocator, generations: []GenerationMetadata) !
 
 var exit_status: u8 = 0;
 
-fn deleteGenerations(allocator: Allocator, generations: []GenerationMetadata, profile_dirname: []const u8) !void {
+pub fn deleteGenerations(allocator: Allocator, generations: []GenerationMetadata, profile_dirname: []const u8) !void {
     var argv = ArrayList([]const u8).init(allocator);
     defer {
         for (argv.items) |s| allocator.free(s);

--- a/src/generation/list.zig
+++ b/src/generation/list.zig
@@ -76,11 +76,11 @@ const GenerationListError = error{
 } || Allocator.Error;
 
 fn listGenerations(allocator: Allocator, profile_name: []const u8, args: GenerationListCommand) GenerationListError!void {
-    const generations = utils.generation.gatherGenerationsFromProfile(allocator, profile_name) catch return GenerationListError.ResourceAccessFailed;
     if (args.interactive) {
-        generationUI(allocator, generations) catch {};
-        return;
+        generationUI(allocator, profile_name) catch return GenerationListError.ResourceAccessFailed;
     }
+
+    const generations = utils.generation.gatherGenerationsFromProfile(allocator, profile_name) catch return GenerationListError.ResourceAccessFailed;
 
     const stdout = io.getStdOut().writer();
 

--- a/src/generation/list.zig
+++ b/src/generation/list.zig
@@ -148,13 +148,13 @@ fn listGenerations(allocator: Allocator, profile_name: []const u8, args: Generat
         }
     }
 
-    if (args.interactive) {
-        generationUI(allocator, generations.items) catch {};
-        return;
-    }
-
     // I like sorted output.
     mem.sort(GenerationMetadata, generations.items, {}, GenerationMetadata.lessThan);
+
+    if (args.interactive) {
+        generationUI(allocator, generations) catch {};
+        return;
+    }
 
     const stdout = io.getStdOut().writer();
 

--- a/src/generation/list.zig
+++ b/src/generation/list.zig
@@ -78,6 +78,7 @@ const GenerationListError = error{
 fn listGenerations(allocator: Allocator, profile_name: []const u8, args: GenerationListCommand) GenerationListError!void {
     if (args.interactive) {
         generationUI(allocator, profile_name) catch return GenerationListError.ResourceAccessFailed;
+        return;
     }
 
     const generations = utils.generation.gatherGenerationsFromProfile(allocator, profile_name) catch return GenerationListError.ResourceAccessFailed;

--- a/src/generation/ui.zig
+++ b/src/generation/ui.zig
@@ -173,7 +173,10 @@ pub const GenerationTUI = struct {
         const gen_list = self.gen_list.items;
         const ctx = self.gen_list_ctx;
 
-        const max_items = if (gen_list.len > table_win.height -| 1) table_win.height -| 1 else gen_list.len;
+        const max_items = if (gen_list.len > table_win.height -| 2)
+            table_win.height -| 2
+        else
+            gen_list.len;
         var end = ctx.start + max_items;
         if (end > gen_list.len) end = gen_list.len;
 
@@ -198,6 +201,13 @@ pub const GenerationTUI = struct {
 
             _ = try tile.printSegment(generation_segment, .{});
         }
+
+        const mode_win: vaxis.Window = main_win.child(.{
+            .y_off = main_win.height - 1,
+            .height = .{ .limit = 1 },
+        });
+        const mode_seg: vaxis.Segment = .{ .text = try fmt.allocPrint(allocator, "{s}", .{@tagName(self.mode)}) };
+        _ = try mode_win.printSegment(mode_seg, .{});
 
         return main_win;
     }

--- a/src/generation/ui.zig
+++ b/src/generation/ui.zig
@@ -1,8 +1,13 @@
 const std = @import("std");
+const fmt = std.fmt;
 const mem = std.mem;
 const Allocator = mem.Allocator;
+const ArrayList = std.ArrayList;
+
+const log = @import("../log.zig");
 
 const vaxis = @import("vaxis");
+const TextInput = vaxis.widgets.TextInput;
 
 const utils = @import("../utils.zig");
 const GenerationMetadata = utils.generation.GenerationMetadata;
@@ -12,31 +17,43 @@ const Event = union(enum) {
     winsize: vaxis.Winsize,
 };
 
-const GenerationTUI = struct {
-    allocator: std.mem.Allocator,
-    should_quit: bool,
+pub const GenerationTUI = struct {
+    allocator: Allocator,
     tty: vaxis.Tty,
     vx: vaxis.Vaxis,
+    should_quit: bool = false,
 
-    pub fn init(allocator: std.mem.Allocator) !GenerationTUI {
-        return .{
+    // Components
+    search_input: TextInput,
+
+    // Generation state
+    gen_list: ArrayList(GenerationMetadata),
+    gen_list_ctx: vaxis.widgets.Table.TableContext,
+
+    const Self = @This();
+
+    pub fn init(allocator: Allocator, gen_list: ArrayList(GenerationMetadata)) !Self {
+        var tty = try vaxis.Tty.init();
+        errdefer tty.deinit();
+
+        const vx = try vaxis.init(allocator, .{});
+        errdefer vx.deinit(allocator, tty.anyWriter());
+
+        const text_input = TextInput.init(allocator, &vx.unicode);
+
+        return GenerationTUI{
             .allocator = allocator,
-            .should_quit = false,
-            .tty = try vaxis.Tty.init(),
-            .vx = try vaxis.init(allocator, .{}),
+            .tty = tty,
+            .vx = vx,
+            .search_input = text_input,
+
+            .gen_list = gen_list,
+            .gen_list_ctx = .{ .selected_bg = .{ .index = 1 } },
         };
     }
 
-    pub fn deinit(self: *GenerationTUI) void {
-        self.vx.deinit(self.allocator, self.tty.anyWriter());
-        self.tty.deinit();
-    }
-
-    pub fn run(self: *GenerationTUI) !void {
-        var loop: vaxis.Loop(Event) = .{
-            .tty = &self.tty,
-            .vaxis = &self.vx,
-        };
+    pub fn run(self: *Self) !void {
+        var loop: vaxis.Loop(Event) = .{ .tty = &self.tty, .vaxis = &self.vx };
         try loop.init();
 
         try loop.start();
@@ -46,54 +63,217 @@ const GenerationTUI = struct {
         try self.vx.queryTerminal(self.tty.anyWriter(), 1 * std.time.ns_per_s);
 
         while (!self.should_quit) {
-            loop.pollEvent();
-            while (loop.tryEvent()) |event| {
-                try self.update(event);
-            }
-            self.draw();
+            // NOTE: This is an arena for drawing stuff, do not remove. This
+            // serves a different purpose than the existing self.allocator.
+            var event_arena = std.heap.ArenaAllocator.init(self.allocator);
+            defer event_arena.deinit();
+            const event_alloc = event_arena.allocator();
 
-            var buffered = self.tty.bufferedWriter();
-            try self.vx.render(buffered.writer().any());
-            try buffered.flush();
+            const event = loop.nextEvent();
+            try self.update(event_alloc, event);
         }
     }
 
-    pub fn update(self: *GenerationTUI, event: Event) !void {
+    pub fn update(self: *Self, allocator: Allocator, event: Event) !void {
         switch (event) {
             .key_press => |key| {
-                if (key.matches('c', .{ .ctrl = true }))
+                if (key.matches('c', .{ .ctrl = true })) {
                     self.should_quit = true;
+                } else if (key.matchesAny(&.{ vaxis.Key.up, 'k' }, .{})) {
+                    self.gen_list_ctx.row -|= 1;
+                } else if (key.matchesAny(&.{ vaxis.Key.down, 'j' }, .{})) {
+                    self.gen_list_ctx.row +|= 1;
+                } else {
+                    try self.search_input.update(.{ .key_press = key });
+                }
             },
             .winsize => |ws| try self.vx.resize(self.allocator, self.tty.anyWriter(), ws),
         }
+
+        try self.draw(allocator);
+        try self.vx.render(self.tty.anyWriter());
     }
 
-    pub fn draw(self: *GenerationTUI) void {
-        const msg = "Hello, world!";
+    fn draw(self: *Self, allocator: Allocator) !void {
         const win = self.vx.window();
         win.clear();
 
-        const child = win.child(.{
-            .x_off = (win.width / 2) - 7,
-            .y_off = win.height / 2 + 1,
-            .width = .{ .limit = msg.len },
-            .height = .{ .limit = 1 },
+        _ = try self.drawGenerationTable(allocator);
+        _ = try self.drawSearchBar();
+        _ = try self.drawGenerationData();
+        _ = try self.drawSelectedGenerations();
+        _ = try self.drawKeybindList();
+    }
+
+    fn drawGenerationTable(self: *Self, allocator: Allocator) !vaxis.Window {
+        const root_win = self.vx.window();
+
+        var main_win = root_win.child(.{
+            .width = .{ .limit = root_win.width / 6 },
+            .height = .{ .limit = root_win.height },
+            .border = .{
+                .where = .all,
+                .style = .{ .fg = .{ .index = 7 } },
+                .glyphs = .single_square,
+            },
+        });
+        const title_seg: vaxis.Segment = .{
+            .text = "Generations",
+            .style = .{ .bold = true },
+        };
+        const title_bar_win: vaxis.Window = main_win.child(.{ .height = .{ .limit = 1 } });
+        const centered: vaxis.Window = vaxis.widgets.alignment.center(title_bar_win, title_seg.text.len, 2);
+        _ = try centered.printSegment(title_seg, .{});
+
+        const table_win: vaxis.Window = main_win.child(.{
+            .y_off = 2,
+            .height = .{ .limit = main_win.height - 2 },
         });
 
-        const style: vaxis.Style = .{
-            .fg = .{
-                .rgb = [3]u8{ 255, 0, 0 },
-            },
+        const gen_list = self.gen_list.items;
+        const ctx = self.gen_list_ctx;
+
+        const max_items = if (gen_list.len > table_win.height -| 1) table_win.height -| 1 else gen_list.len;
+        var end = ctx.start + max_items;
+        if (end > gen_list.len) end = gen_list.len;
+
+        // TODO: fix starting point for rendering
+        const selected_row = blk: {
+            var row = ctx.row;
+            if (row > gen_list.len - 1) row = gen_list.len - 1;
+            break :blk row;
         };
 
-        _ = try child.printSegment(.{ .text = msg, .style = style }, .{});
+        for (gen_list[ctx.start..end], 0..) |data, i| {
+            const tile = table_win.child(.{
+                .x_off = 3,
+                .y_off = i,
+                .width = .{ .limit = table_win.width },
+                .height = .{ .limit = 1 },
+            });
+
+            const generation_segment: vaxis.Segment = .{
+                .text = try fmt.allocPrint(allocator, "{d}", .{data.generation.?}),
+                .style = .{
+                    .fg = if (data.current) .{ .index = 2 } else .{ .index = 7 },
+                    .bg = if (selected_row == i) .{ .index = 6 } else .{ .index = 0 },
+                },
+            };
+
+            _ = try tile.printSegment(generation_segment, .{});
+        }
+
+        return main_win;
+    }
+
+    /// Input bar for searching generations by description.
+    fn drawSearchBar(self: *Self) !vaxis.Window {
+        const root_win = self.vx.window();
+
+        const search_bar_win = root_win.child(.{
+            .x_off = root_win.width / 6,
+            .y_off = root_win.height - 3,
+            .width = .{ .limit = root_win.width - (root_win.width / 6) },
+            .height = .{ .limit = 3 },
+            .border = .{
+                .where = .all,
+                .style = .{ .fg = .{ .index = 7 } },
+                .glyphs = .single_square,
+            },
+        });
+        self.search_input.draw(search_bar_win);
+
+        return search_bar_win;
+    }
+
+    /// Print the information for a selected generation.
+    fn drawGenerationData(self: *Self) !vaxis.Window {
+        const root_win = self.vx.window();
+
+        const main_win: vaxis.Window = root_win.child(.{
+            .x_off = root_win.width / 6,
+            .width = .{ .limit = root_win.width / 2 },
+            .height = .{ .limit = root_win.height - 3 },
+            .border = .{
+                .where = .all,
+                .style = .{ .fg = .{ .index = 7 } },
+                .glyphs = .single_square,
+            },
+        });
+        const title_seg: vaxis.Segment = .{
+            .text = "Information",
+            .style = .{ .bold = true },
+        };
+        const title_bar_win: vaxis.Window = main_win.child(.{ .height = .{ .limit = 1 } });
+        const centered: vaxis.Window = vaxis.widgets.alignment.center(title_bar_win, title_seg.text.len, 2);
+        _ = try centered.printSegment(title_seg, .{});
+
+        return main_win;
+    }
+
+    /// Draw the selected generations to delete (to make it easier
+    /// to grok without looking at the generation list markings)
+    fn drawSelectedGenerations(self: *Self) !vaxis.Window {
+        const root = self.vx.window();
+
+        const main_win: vaxis.Window = root.child(.{
+            .x_off = (root.width * 2) / 3,
+            .width = .{ .limit = root.width / 3 },
+            .height = .{ .limit = root.height / 2 },
+            .border = .{
+                .where = .all,
+                .style = .{
+                    .fg = .{ .index = 7 },
+                },
+                .glyphs = .single_square,
+            },
+        });
+        const title_seg: vaxis.Segment = .{
+            .text = "Selected Generations",
+            .style = .{ .bold = true },
+        };
+        const title_win: vaxis.Window = main_win.child(.{ .height = .{ .limit = 1 } });
+        const centered: vaxis.Window = vaxis.widgets.alignment.center(title_win, title_seg.text.len, 2);
+        _ = try centered.printSegment(title_seg, .{});
+
+        return main_win;
+    }
+
+    /// Draw the list of available keymaps (vaguely less-like)
+    fn drawKeybindList(self: *Self) !vaxis.Window {
+        const root_win = self.vx.window();
+
+        const main_win: vaxis.Window = root_win.child(.{
+            .x_off = (root_win.width * 2) / 3,
+            .y_off = root_win.height / 2,
+            .width = .{ .limit = root_win.width / 3 },
+            .height = .{ .limit = root_win.height / 2 - 2 },
+            .border = .{
+                .where = .all,
+                .style = .{ .fg = .{ .index = 7 } },
+                .glyphs = .single_square,
+            },
+        });
+        const title_seg: vaxis.Segment = .{
+            .text = "Keybinds",
+            .style = .{ .bold = true },
+        };
+        const title_win: vaxis.Window = main_win.child(.{ .height = .{ .limit = 1 } });
+        const centered: vaxis.Window = vaxis.widgets.alignment.center(title_win, title_seg.text.len, 2);
+        _ = try centered.printSegment(title_seg, .{});
+
+        return main_win;
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.search_input.deinit();
+        self.vx.deinit(self.allocator, self.tty.anyWriter());
+        self.tty.deinit();
     }
 };
 
-pub fn generationUI(allocator: Allocator, generations: []GenerationMetadata) !void {
-    _ = generations;
-
-    var app = try GenerationTUI.init(allocator);
+pub fn generationUI(allocator: Allocator, generations: ArrayList(GenerationMetadata)) !void {
+    var app = try GenerationTUI.init(allocator, generations);
     defer app.deinit();
 
     try app.run();

--- a/src/generation/ui.zig
+++ b/src/generation/ui.zig
@@ -1,0 +1,100 @@
+const std = @import("std");
+const mem = std.mem;
+const Allocator = mem.Allocator;
+
+const vaxis = @import("vaxis");
+
+const utils = @import("../utils.zig");
+const GenerationMetadata = utils.generation.GenerationMetadata;
+
+const Event = union(enum) {
+    key_press: vaxis.Key,
+    winsize: vaxis.Winsize,
+};
+
+const GenerationTUI = struct {
+    allocator: std.mem.Allocator,
+    should_quit: bool,
+    tty: vaxis.Tty,
+    vx: vaxis.Vaxis,
+
+    pub fn init(allocator: std.mem.Allocator) !GenerationTUI {
+        return .{
+            .allocator = allocator,
+            .should_quit = false,
+            .tty = try vaxis.Tty.init(),
+            .vx = try vaxis.init(allocator, .{}),
+        };
+    }
+
+    pub fn deinit(self: *GenerationTUI) void {
+        self.vx.deinit(self.allocator, self.tty.anyWriter());
+        self.tty.deinit();
+    }
+
+    pub fn run(self: *GenerationTUI) !void {
+        var loop: vaxis.Loop(Event) = .{
+            .tty = &self.tty,
+            .vaxis = &self.vx,
+        };
+        try loop.init();
+
+        try loop.start();
+        defer loop.stop();
+
+        try self.vx.enterAltScreen(self.tty.anyWriter());
+        try self.vx.queryTerminal(self.tty.anyWriter(), 1 * std.time.ns_per_s);
+
+        while (!self.should_quit) {
+            loop.pollEvent();
+            while (loop.tryEvent()) |event| {
+                try self.update(event);
+            }
+            self.draw();
+
+            var buffered = self.tty.bufferedWriter();
+            try self.vx.render(buffered.writer().any());
+            try buffered.flush();
+        }
+    }
+
+    pub fn update(self: *GenerationTUI, event: Event) !void {
+        switch (event) {
+            .key_press => |key| {
+                if (key.matches('c', .{ .ctrl = true }))
+                    self.should_quit = true;
+            },
+            .winsize => |ws| try self.vx.resize(self.allocator, self.tty.anyWriter(), ws),
+        }
+    }
+
+    pub fn draw(self: *GenerationTUI) void {
+        const msg = "Hello, world!";
+        const win = self.vx.window();
+        win.clear();
+
+        const child = win.child(.{
+            .x_off = (win.width / 2) - 7,
+            .y_off = win.height / 2 + 1,
+            .width = .{ .limit = msg.len },
+            .height = .{ .limit = 1 },
+        });
+
+        const style: vaxis.Style = .{
+            .fg = .{
+                .rgb = [3]u8{ 255, 0, 0 },
+            },
+        };
+
+        _ = try child.printSegment(.{ .text = msg, .style = style }, .{});
+    }
+};
+
+pub fn generationUI(allocator: Allocator, generations: []GenerationMetadata) !void {
+    _ = generations;
+
+    var app = try GenerationTUI.init(allocator);
+    defer app.deinit();
+
+    try app.run();
+}

--- a/src/generation/ui.zig
+++ b/src/generation/ui.zig
@@ -92,19 +92,19 @@ pub const GenerationTUI = struct {
 
     pub fn update(self: *Self, allocator: Allocator, event: Event) !void {
         switch (event) {
-            .key_press => |key| {
+            .key_press => |key| blk: {
                 // Arrow keys and CTRL codes should work regardless of input mode
                 if (key.matches(vaxis.Key.up, .{})) {
                     self.gen_list_ctx.row -|= 1;
-                    return;
+                    break :blk;
                 } else if (key.matches(vaxis.Key.down, .{})) {
                     if (self.gen_list_ctx.row < self.gen_list.items.len - 1) {
                         self.gen_list_ctx.row +|= 1;
                     }
-                    return;
+                    break :blk;
                 } else if (key.matches('c', .{ .ctrl = true })) {
                     self.should_quit = true;
-                    return;
+                    break :blk;
                 }
 
                 if (self.mode == .input) {

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -395,6 +395,22 @@ pub fn verifyLegacyConfigurationExists(allocator: Allocator, verbose: bool) !voi
     }
 }
 
+pub fn confirmationInput() !bool {
+    // This large buffer is to prevent users from seeing an error if they
+    // make an extremely large typo. People who are trying to buffer overflow
+    // are in for the error message though!
+    var input_buf: [100]u8 = undefined;
+    const stdin = io.getStdIn().reader();
+
+    log.print("Proceed? [y/n]: ", .{});
+    const input = stdin.readUntilDelimiter(&input_buf, '\n') catch |err| {
+        log.err("unable to read stdin for confirmation: {s}", .{@errorName(err)});
+        return err;
+    };
+
+    return input.len > 0 and std.ascii.toLower(input[0]) == 'y';
+}
+
 pub const search = @import("utils/search.zig");
 pub const generation = @import("utils/generation.zig");
 pub const ansi = @import("utils/ansi.zig");

--- a/src/utils/ansi.zig
+++ b/src/utils/ansi.zig
@@ -20,3 +20,6 @@ pub const RESET = "\x1B[0m";
 pub const BOLD = "\x1B[1m";
 pub const ITALIC = "\x1B[3m";
 pub const UNDERLINE = "\x1B[4m";
+
+pub const CLEAR = "\x1B[2J";
+pub const MV_TOP_LEFT = "\x1B[H";

--- a/src/utils/generation.zig
+++ b/src/utils/generation.zig
@@ -3,8 +3,10 @@ const fmt = std.fmt;
 const fs = std.fs;
 const json = std.json;
 const mem = std.mem;
+const posix = std.posix;
 const sort = std.sort;
 const Allocator = mem.Allocator;
+const ArrayList = std.ArrayList;
 
 const log = @import("../log.zig");
 
@@ -337,3 +339,85 @@ pub const GenerationMetadata = struct {
         try out.endObject();
     }
 };
+
+pub fn gatherGenerationsFromProfile(allocator: Allocator, profile_name: []const u8) ![]GenerationMetadata {
+    const profile_dirname = if (mem.eql(u8, profile_name, "system"))
+        "/nix/var/nix/profiles"
+    else
+        "/nix/var/nix/profiles/system-profiles";
+
+    var generations: ArrayList(GenerationMetadata) = ArrayList(GenerationMetadata).init(allocator);
+    errdefer {
+        for (generations.items) |*generation| {
+            generation.deinit();
+        }
+        generations.deinit();
+    }
+
+    var generations_dir = fs.cwd().openDir(profile_dirname, .{ .iterate = true }) catch |err| {
+        log.err("unexpected error encountered opening {s}: {s}", .{ profile_dirname, @errorName(err) });
+        return err;
+    };
+    defer generations_dir.close();
+
+    var path_buf: [posix.PATH_MAX]u8 = undefined;
+
+    const current_generation_dirname = try fs.path.join(allocator, &.{ profile_dirname, profile_name });
+    defer allocator.free(current_generation_dirname);
+
+    // Check if generation is the current generation
+    const current_system_name = posix.readlink(current_generation_dirname, &path_buf) catch |err| {
+        log.err("unable to readlink {s}: {s}", .{ current_generation_dirname, @errorName(err) });
+        return err;
+    };
+
+    var iter = generations_dir.iterate();
+    while (iter.next() catch |err| {
+        log.err("unexpected error while reading profile directory: {s}", .{@errorName(err)});
+        return err;
+    }) |entry| {
+        const prefix = try fmt.allocPrint(allocator, "{s}-", .{profile_name});
+        defer allocator.free(prefix);
+
+        // I hate no regexes in this language. Big sad.
+        // This works around the fact that multiple profile
+        // names can share the same prefix.
+        if (mem.startsWith(u8, entry.name, prefix) and
+            mem.endsWith(u8, entry.name, "-link") and
+            prefix.len + 5 < entry.name.len)
+        {
+            const gen_number_slice = entry.name[(prefix.len)..mem.indexOf(u8, entry.name, "-link").?];
+
+            // If the number parsed is not an integer, it contains a dash
+            // and is from another profile, so it is skipped.
+            // Also, might as well pass this to the generation info
+            // function and avoid extra work re-parsing the number.
+            const generation_number = std.fmt.parseInt(usize, gen_number_slice, 10) catch continue;
+
+            const generation_dirname = try fs.path.join(allocator, &.{ profile_dirname, entry.name });
+            defer allocator.free(generation_dirname);
+
+            // Skipping generations with `continue` is not a good idea.
+            // Many places in the code rely on the assumption that there
+            // is *always* one current generation.
+            var generation_dir = fs.openDirAbsolute(generation_dirname, .{}) catch |err| {
+                log.err("unexpected error encountered opening {s}: {s}", .{ generation_dirname, @errorName(err) });
+                return err;
+            };
+            defer generation_dir.close();
+
+            var generation = try GenerationMetadata.getGenerationInfo(allocator, generation_dir, generation_number);
+            errdefer generation.deinit();
+
+            if (mem.eql(u8, current_system_name, entry.name)) {
+                generation.current = true;
+            }
+
+            try generations.append(generation);
+        }
+    }
+
+    mem.sort(GenerationMetadata, generations.items, {}, GenerationMetadata.lessThan);
+
+    return try generations.toOwnedSlice();
+}

--- a/src/utils/generation.zig
+++ b/src/utils/generation.zig
@@ -113,6 +113,8 @@ pub const GenerationMetadata = struct {
             const ctime = zeit.instant(.{ .source = .{ .unix_nano = stat.ctime } }) catch break :blk;
 
             const local_tz = zeit.local(allocator) catch break :blk;
+            defer local_tz.deinit();
+
             result.date = ctime.in(&local_tz).time();
         }
 


### PR DESCRIPTION
# Motivation

This PR brings in a TUI for managing generations.

![2024-08-10_20-49-46](https://github.com/user-attachments/assets/7af89f4e-dd16-4408-931f-bab1ba1e1b7e)

Listing generations is a bit annoying to grok, whether it's in table format or something else like that. This allows you to scroll a list of generations and view information about each one, filter generations by their description, and delete generations using `nixos generation delete`.

As a bonus, there are very primitive `vim`-like keybinds (`k/j` to move up/down, `q` to quit, `/` to search by generation description, etc.) 