### PR TITLE
feat: show system diff for any activations

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -1,5 +1,8 @@
 # Where to look for configuration by default
 config_location = "/etc/nixos"
+# Use `nvd` (https://gitlab.com/khumba/nvd) instead of
+# `nix store diff-closures` when showing closure diffs
+use_nvd = false
 
 # Aliases for long commands that you don't want to type out. All arguments
 # after the aliases are passed as-is to the underlying command.

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -1,5 +1,8 @@
 # Where to look for configuration by default
 config_location = "/etc/nixos"
+# Disable confirmation dialogs. This is good for ensuring
+# that commands will run to completion without user input.
+no_confirm = false
 # Use `nvd` (https://gitlab.com/khumba/nvd) instead of
 # `nix store diff-closures` when showing closure diffs
 use_nvd = false

--- a/src/apply.zig
+++ b/src/apply.zig
@@ -713,6 +713,7 @@ fn apply(allocator: Allocator, args: ApplyCommand) ApplyError!void {
 
     // Ask for confirmation, if needed
     if (!args.yes and !args.dry) {
+        log.print("\n", .{});
         const confirm = utils.confirmationInput("Activate this configuration") catch |err| {
             log.err("unable to read stdin for confirmation: {s}", .{@errorName(err)});
             return ApplyError.ResourceAccessFailed;

--- a/src/apply.zig
+++ b/src/apply.zig
@@ -712,7 +712,7 @@ fn apply(allocator: Allocator, args: ApplyCommand) ApplyError!void {
     }
 
     // Ask for confirmation, if needed
-    if (!args.yes and !args.dry) {
+    if (!args.yes and !c.no_confirm and !args.dry) {
         log.print("\n", .{});
         const confirm = utils.confirmationInput("Activate this configuration") catch |err| {
             log.err("unable to read stdin for confirmation: {s}", .{@errorName(err)});

--- a/src/apply.zig
+++ b/src/apply.zig
@@ -702,6 +702,15 @@ fn apply(allocator: Allocator, args: ApplyCommand) ApplyError!void {
         return;
     }
 
+    log.step("Comparing changes...", .{});
+    const diff_cmd_status = utils.generation.diff(allocator, Constants.current_system, result, verbose) catch |err| blk: {
+        log.warn("diff command failed to run: {s}", .{@errorName(err)});
+        break :blk 0;
+    };
+    if (diff_cmd_status != 0) {
+        log.warn("diff command exited with status {d}", .{diff_cmd_status});
+    }
+
     // Ask for confirmation, if needed
     if (!args.yes and !args.dry) {
         const confirm = utils.confirmationInput("Activate this configuration") catch |err| {

--- a/src/config.zig
+++ b/src/config.zig
@@ -33,6 +33,7 @@ pub const Config = struct {
         extra_attrs: ?toml.Table = null,
         extra_config: ?[]const u8 = null,
     } = .{},
+    no_confirm: bool = false,
     use_nvd: bool = false,
 };
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -33,6 +33,7 @@ pub const Config = struct {
         extra_attrs: ?toml.Table = null,
         extra_config: ?[]const u8 = null,
     } = .{},
+    use_nvd: bool = false,
 };
 
 var config_value: ?toml.Parsed(Config) = null;

--- a/src/generation/delete.zig
+++ b/src/generation/delete.zig
@@ -499,7 +499,7 @@ pub fn generationDelete(allocator: Allocator, args: GenerationDeleteCommand, pro
     log.print("There will be {d} generations left on this machine.\n", .{remaining_number_of_generations});
 
     if (!args.yes) {
-        const confirm = utils.confirmationInput() catch |err| {
+        const confirm = utils.confirmationInput("Proceed") catch |err| {
             log.err("unable to read stdin for confirmation: {s}", .{@errorName(err)});
             return GenerationDeleteError.ResourceAccessFailed;
         };

--- a/src/generation/rollback.zig
+++ b/src/generation/rollback.zig
@@ -150,9 +150,8 @@ fn rollbackGeneration(allocator: Allocator, args: GenerationRollbackCommand, pro
 
     // Ask for confirmation, if needed
     if (!args.yes) {
-        const prompt = try fmt.allocPrint(allocator, "Activate previous generation", .{});
-        defer allocator.free(prompt);
-        const confirm = utils.confirmationInput(prompt) catch |err| {
+        log.print("\n", .{});
+        const confirm = utils.confirmationInput("Activate previous generation") catch |err| {
             log.err("unable to read stdin for confirmation: {s}", .{@errorName(err)});
             return GenerationRollbackError.ResourceAccessFailed;
         };

--- a/src/generation/rollback.zig
+++ b/src/generation/rollback.zig
@@ -14,6 +14,8 @@ const argIs = argparse.argIs;
 const getNextArgs = argparse.getNextArgs;
 const ArgParseError = argparse.ArgParseError;
 
+const config = @import("../config.zig");
+
 const Constants = @import("../constants.zig");
 
 const log = @import("../log.zig");
@@ -126,6 +128,8 @@ fn runSwitchToConfiguration(
 fn rollbackGeneration(allocator: Allocator, args: GenerationRollbackCommand, profile_name: []const u8) !void {
     verbose = args.verbose;
 
+    const c = config.getConfig();
+
     if (linux.geteuid() != 0) {
         utils.execAsRoot(allocator) catch |err| {
             log.err("unable to re-exec this command as root: {s}", .{@errorName(err)});
@@ -176,7 +180,7 @@ fn rollbackGeneration(allocator: Allocator, args: GenerationRollbackCommand, pro
     }
 
     // Ask for confirmation, if needed
-    if (!args.yes) {
+    if (!args.yes and !c.no_confirm) {
         log.print("\n", .{});
         const confirm = utils.confirmationInput("Activate previous generation") catch |err| {
             log.err("unable to read stdin for confirmation: {s}", .{@errorName(err)});

--- a/src/generation/switch.zig
+++ b/src/generation/switch.zig
@@ -14,6 +14,8 @@ const argIs = argparse.argIs;
 const getNextArgs = argparse.getNextArgs;
 const ArgParseError = argparse.ArgParseError;
 
+const config = @import("../config.zig");
+
 const Constants = @import("../constants.zig");
 
 const log = @import("../log.zig");
@@ -152,6 +154,8 @@ pub fn switchGeneration(allocator: Allocator, args: GenerationSwitchCommand, pro
     const generation = args.gen_number.?;
     verbose = args.verbose;
 
+    const c = config.getConfig();
+
     if (linux.geteuid() != 0) {
         utils.execAsRoot(allocator) catch |err| {
             log.err("unable to re-exec this command as root: {s}", .{@errorName(err)});
@@ -190,7 +194,7 @@ pub fn switchGeneration(allocator: Allocator, args: GenerationSwitchCommand, pro
     }
 
     // Ask for confirmation, if needed
-    if (!args.yes) {
+    if (!args.yes and !c.no_confirm) {
         const prompt = try fmt.allocPrint(allocator, "Activate generation {s}", .{generation});
         defer allocator.free(prompt);
 

--- a/src/generation/switch.zig
+++ b/src/generation/switch.zig
@@ -30,6 +30,7 @@ pub const GenerationSwitchCommand = struct {
     verbose: bool = false,
     dry: bool = false,
     specialization: ?[]const u8 = null,
+    yes: bool = false,
     gen_number: ?[]const u8 = null,
 
     const usage =
@@ -46,6 +47,7 @@ pub const GenerationSwitchCommand = struct {
         \\    -h, --help              Show this help menu
         \\    -s, --specialisation    Activate the given specialisation
         \\    -v, --verbose           Show verbose logging
+        \\    -y, --yes               Automatically confirm activation
         \\
     ;
 
@@ -63,6 +65,8 @@ pub const GenerationSwitchCommand = struct {
                 parsed.specialization = next;
             } else if (argIs(arg, "--verbose", "-v")) {
                 parsed.verbose = true;
+            } else if (argIs(arg, "--yes", "-y")) {
+                parsed.yes = true;
             } else if (argparse.isFlag(arg)) {
                 return arg;
             } else {
@@ -176,7 +180,30 @@ pub fn switchGeneration(allocator: Allocator, args: GenerationSwitchCommand, pro
         return GenerationSwitchError.ResourceAccessFailed;
     };
 
-    log.info("activating generation {s}...", .{generation});
+    log.step("Comparing changes...", .{});
+    const diff_cmd_status = utils.generation.diff(allocator, Constants.current_system, profile_link, verbose) catch |err| blk: {
+        log.warn("diff command failed to run: {s}", .{@errorName(err)});
+        break :blk 0;
+    };
+    if (diff_cmd_status != 0) {
+        log.warn("diff command exited with status {d}", .{diff_cmd_status});
+    }
+
+    // Ask for confirmation, if needed
+    if (!args.yes) {
+        const prompt = try fmt.allocPrint(allocator, "Activate generation {s}", .{generation});
+        defer allocator.free(prompt);
+        const confirm = utils.confirmationInput(prompt) catch |err| {
+            log.err("unable to read stdin for confirmation: {s}", .{@errorName(err)});
+            return GenerationSwitchError.ResourceAccessFailed;
+        };
+        if (!confirm) {
+            log.warn("confirmation was not given, not proceeding with activation", .{});
+            return;
+        }
+    }
+
+    log.step("Activating generation {s}...", .{generation});
 
     // Switch generation profile
     setNixEnvProfile(allocator, current_profile_dirname, generation, args.dry) catch {

--- a/src/generation/switch.zig
+++ b/src/generation/switch.zig
@@ -193,6 +193,8 @@ pub fn switchGeneration(allocator: Allocator, args: GenerationSwitchCommand, pro
     if (!args.yes) {
         const prompt = try fmt.allocPrint(allocator, "Activate generation {s}", .{generation});
         defer allocator.free(prompt);
+
+        log.print("\n", .{});
         const confirm = utils.confirmationInput(prompt) catch |err| {
             log.err("unable to read stdin for confirmation: {s}", .{@errorName(err)});
             return GenerationSwitchError.ResourceAccessFailed;

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -395,14 +395,14 @@ pub fn verifyLegacyConfigurationExists(allocator: Allocator, verbose: bool) !voi
     }
 }
 
-pub fn confirmationInput() !bool {
+pub fn confirmationInput(prompt: []const u8) !bool {
     // This large buffer is to prevent users from seeing an error if they
     // make an extremely large typo. People who are trying to buffer overflow
     // are in for the error message though!
     var input_buf: [100]u8 = undefined;
     const stdin = io.getStdIn().reader();
 
-    log.print("Proceed? [y/n]: ", .{});
+    log.print("{s}? [y/n]: ", .{prompt});
     const input = stdin.readUntilDelimiter(&input_buf, '\n') catch |err| {
         log.err("unable to read stdin for confirmation: {s}", .{@errorName(err)});
         return err;

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -15,6 +15,8 @@ const EnvMap = process.EnvMap;
 
 const config = @import("config.zig");
 
+const Constants = @import("constants.zig");
+
 const log = @import("./log.zig");
 
 /// Print to a writer, ignoring errors.
@@ -402,7 +404,12 @@ pub fn confirmationInput(prompt: []const u8) !bool {
     var input_buf: [100]u8 = undefined;
     const stdin = io.getStdIn().reader();
 
-    log.print("{s}? [y/n]: ", .{prompt});
+    if (Constants.use_color) {
+        log.print(ansi.GREEN ++ "|> {s}?" ++ ansi.RESET ++ "\n[y/n]: ", .{prompt});
+    } else {
+        log.print("|> {s}?\n[y/n]: ", .{prompt});
+    }
+
     const input = stdin.readUntilDelimiter(&input_buf, '\n') catch |err| {
         log.err("unable to read stdin for confirmation: {s}", .{@errorName(err)});
         return err;

--- a/src/utils/generation.zig
+++ b/src/utils/generation.zig
@@ -421,3 +421,22 @@ pub fn gatherGenerationsFromProfile(allocator: Allocator, profile_name: []const 
 
     return try generations.toOwnedSlice();
 }
+
+/// Show a diff between two generation closures to the user.
+pub fn diff(allocator: Allocator, before: []const u8, after: []const u8, verbose: bool) !u8 {
+    // TODO: grab config value for use_nvd and use it here to
+    // determine what `argv` is.
+
+    // By default, run `nix store diff-closures`.
+    const argv = &.{ "nix", "store", "diff-closures", before, after };
+
+    if (verbose) log.cmd(argv);
+
+    const result = try utils.runCmd(.{
+        .allocator = allocator,
+        .argv = argv,
+        .stdout_type = .Inherit,
+    });
+
+    return result.status;
+}


### PR DESCRIPTION
A lot of users like to see the difference between two generations before an activation so that they can see what has changed.

While we have `nixos generation diff`, this runs after the fact. This PR allows users to see a system closure diff between the current system and system closure to activate.

Additionally, it allows setting the diff provider to either [`nvd`](https://gitlab.com/khumba/nvd) or `nix store diff-closures` (the default); most people prefer `nvd`, but the default is probably available on more systems, so it's better to keep this on an opt-in basis like `nix-output-monitor` for `nixos apply`.

Finally, it brings in interactive confirmation for activation commands (`apply`, `generation rollback`, `generation switch`). This allows users to scroll the diff before applying the configuration.