### PR TITLE
feat: add option search UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,19 +103,20 @@ configuration is located in [`config.sample.toml`](./config.sample.toml).
   - ✅ `delete`
   - ✅ `diff`
 - ✅ `manual`
-- ➖ `option`
+- ✅ `option`
 - ✅ `repl`
 
 ### Roadmap
 
 - ❌ CLI completion
 - ❌ Documentation (via man pages)
-- ❌ Options search (a la https://search.nixos.org)
+- ✅ Options search (a la https://search.nixos.org)
 - ❌ Remote installation (a la [`nixos-anywhere`](https;//github.com/numtide/nixos-anywhere))
 - ❌ Remote application of configurations
 - ❌ Container management (Maybe? This is lower priority.)
 
-Check the [issues] page for more on this; this is just a high-level overview.
+Check the [issues](https://github.com/water-sucks/nixos/issues) page for more on
+this; this is just a high-level overview.
 
 ### Possible Future Commands
 

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -41,6 +41,13 @@ desktop_config = ""
 # Extra configuration to append to `configuration.nix` as a string
 extra_config = ""
 
+# Configuration for the `option` subcommand.
+[option]
+# The maximum distance score allowed for search results. This can be any number
+# above 1; higher scores will give less relevant results, while smaller scores
+# will be more strict in matching.
+max_rank = 3.00
+
 # Extra configuration to append to `configuration.nix`,
 # as structured key-value pairs
 [init.extra_attrs]

--- a/src/main.zig
+++ b/src/main.zig
@@ -275,6 +275,7 @@ pub fn main() !u8 {
     for (structured_args.config_values.items) |pair| {
         config.setConfigValue(pair) catch return 2;
     }
+    config.validateConfig(allocator) catch return 2;
 
     const status = switch (structured_args.subcommand.?) {
         .aliases => |args| {

--- a/src/option.zig
+++ b/src/option.zig
@@ -28,10 +28,13 @@ const println = utils.println;
 const search = utils.search;
 const ansi = utils.ansi;
 
+const optionSearchUI = @import("option/ui.zig").optionSearchUI;
+
 pub const OptionError = error{
     NoOptionCache,
     NoResultFound,
     UnsupportedOs,
+    ResourceAccessFailed,
 };
 
 pub const OptionCommand = struct {
@@ -314,7 +317,7 @@ fn option(allocator: Allocator, args: OptionCommand) !void {
     }
 
     if (args.interactive) {
-        log.info("this is currently unimplemented; coming soon!", .{});
+        optionSearchUI(allocator) catch return OptionError.ResourceAccessFailed;
         return;
     }
 
@@ -416,6 +419,7 @@ fn option(allocator: Allocator, args: OptionCommand) !void {
 pub fn optionMain(allocator: Allocator, args: OptionCommand) u8 {
     option(allocator, args) catch |err| switch (err) {
         OptionError.UnsupportedOs => return 3,
+        OptionError.ResourceAccessFailed => return 4,
         else => return 1,
     };
 

--- a/src/option.zig
+++ b/src/option.zig
@@ -114,7 +114,7 @@ pub const OptionCommand = struct {
     }
 };
 
-const NixosOption = struct {
+pub const NixosOption = struct {
     name: []const u8,
     description: ?[]const u8 = null,
     type: []const u8,
@@ -316,11 +316,6 @@ fn option(allocator: Allocator, args: OptionCommand) !void {
         return OptionError.UnsupportedOs;
     }
 
-    if (args.interactive) {
-        optionSearchUI(allocator) catch return OptionError.ResourceAccessFailed;
-        return;
-    }
-
     var options_filename_alloc = false;
     const options_filename = blk: {
         if (!args.no_cache and fileExistsAbsolute(prebuilt_options_cache_filename)) {
@@ -341,6 +336,11 @@ fn option(allocator: Allocator, args: OptionCommand) !void {
     try options_list.setCapacity(allocator, parsed_options.value.len);
     for (parsed_options.value) |opt| {
         options_list.appendAssumeCapacity(opt);
+    }
+
+    if (args.interactive) {
+        optionSearchUI(allocator, parsed_options.value) catch return OptionError.ResourceAccessFailed;
+        return;
     }
 
     const option_input = args.option.?;

--- a/src/option.zig
+++ b/src/option.zig
@@ -322,6 +322,7 @@ fn option(allocator: Allocator, args: OptionCommand) !void {
             break :blk prebuilt_options_cache_filename;
         }
         options_filename_alloc = true;
+        log.info("building option list cache, please wait...", .{});
         break :blk try findNixosOptionFilepath(allocator, args.includes.items);
     };
     defer if (options_filename_alloc) allocator.free(options_filename);

--- a/src/option/ui.zig
+++ b/src/option/ui.zig
@@ -1,0 +1,194 @@
+const std = @import("std");
+const fmt = std.fmt;
+const mem = std.mem;
+const process = std.process;
+const Allocator = mem.Allocator;
+const ArrayList = std.ArrayList;
+
+const log = @import("../log.zig");
+
+const vaxis = @import("vaxis");
+const TextInput = vaxis.widgets.TextInput;
+
+const utils = @import("../utils.zig");
+const ansi = utils.ansi;
+const runCmd = utils.runCmd;
+const GenerationMetadata = utils.generation.GenerationMetadata;
+const CandidateStruct = utils.search.CandidateStruct;
+
+const Event = union(enum) {
+    key_press: vaxis.Key,
+    winsize: vaxis.Winsize,
+};
+
+pub const OptionSearchTUI = struct {
+    allocator: Allocator,
+    tty: vaxis.Tty,
+    vx: vaxis.Vaxis,
+    should_quit: bool = false,
+    text_input: TextInput,
+
+    const Self = @This();
+
+    pub fn init(allocator: Allocator) !Self {
+        var tty = try vaxis.Tty.init();
+        errdefer tty.deinit();
+
+        var vx = try vaxis.init(allocator, .{});
+        errdefer vx.deinit(allocator, tty.anyWriter());
+
+        var text_input = TextInput.init(allocator, &vx.unicode);
+        errdefer text_input.deinit();
+
+        return OptionSearchTUI{
+            .allocator = allocator,
+            .tty = tty,
+            .vx = vx,
+            .text_input = text_input,
+        };
+    }
+
+    pub fn run(self: *Self) !void {
+        var loop: vaxis.Loop(Event) = .{ .tty = &self.tty, .vaxis = &self.vx };
+        try loop.init();
+
+        try loop.start();
+        defer loop.stop();
+
+        try self.vx.enterAltScreen(self.tty.anyWriter());
+        try self.vx.queryTerminal(self.tty.anyWriter(), 1 * std.time.ns_per_s);
+
+        while (!self.should_quit) {
+            // NOTE: This is an arena for drawing stuff, do not remove. This
+            // serves a different purpose than the existing self.allocator.
+            var event_arena = std.heap.ArenaAllocator.init(self.allocator);
+            defer event_arena.deinit();
+            const event_alloc = event_arena.allocator();
+
+            const event = loop.nextEvent();
+            try self.update(event_alloc, event);
+        }
+    }
+
+    pub fn update(self: *Self, allocator: Allocator, event: Event) !void {
+        switch (event) {
+            .key_press => |key| {
+                if (key.matches('c', .{ .ctrl = true })) {
+                    self.should_quit = true;
+                } else {
+                    try self.text_input.update(.{ .key_press = key });
+                }
+            },
+            .winsize => |ws| try self.vx.resize(self.allocator, self.tty.anyWriter(), ws),
+        }
+
+        try self.draw(allocator);
+        try self.vx.render(self.tty.anyWriter());
+    }
+
+    fn draw(self: *Self, allocator: Allocator) !void {
+        _ = allocator;
+
+        const root_win = self.vx.window();
+        root_win.clear();
+
+        _ = try self.drawResultsList();
+        _ = try self.drawSearchBar();
+        _ = try self.drawResultPreview();
+    }
+
+    fn drawResultsList(self: *Self) !vaxis.Window {
+        const root_win = self.vx.window();
+
+        var main_win = root_win.child(.{
+            .width = .{ .limit = root_win.width / 2 },
+            .height = .{ .limit = root_win.height - 3 },
+            .border = .{
+                .where = .all,
+                .style = .{ .fg = .{ .index = 7 } },
+                .glyphs = .single_square,
+            },
+        });
+
+        const title_seg: vaxis.Segment = .{
+            .text = "Results",
+            .style = .{ .bold = true },
+        };
+        const title_win: vaxis.Window = main_win.child(.{ .height = .{ .limit = 1 } });
+
+        const centered: vaxis.Window = vaxis.widgets.alignment.center(title_win, title_seg.text.len, 2);
+        _ = try centered.printSegment(title_seg, .{});
+
+        return main_win;
+    }
+
+    fn drawSearchBar(self: *Self) !vaxis.Window {
+        const root_win = self.vx.window();
+
+        const search_bar_win = root_win.child(.{
+            .y_off = root_win.height - 3,
+            .width = .{ .limit = root_win.width / 2 },
+            .height = .{ .limit = 3 },
+            .border = .{
+                .where = .all,
+                .style = .{ .fg = .{ .index = 7 } },
+                .glyphs = .single_square,
+            },
+        });
+
+        const placeholder_seg: vaxis.Segment = .{ .text = "Search for options...", .style = .{
+            .fg = .{ .index = 4 },
+        } };
+
+        _ = try search_bar_win.printSegment(.{ .text = ">" }, .{});
+
+        var input_win = search_bar_win.child(.{
+            .x_off = 2,
+            .width = .{ .limit = search_bar_win.width - 2 },
+        });
+        self.text_input.draw(input_win);
+        if (self.text_input.buf.items.len == 0) {
+            _ = try input_win.printSegment(placeholder_seg, .{});
+        }
+
+        return search_bar_win;
+    }
+
+    fn drawResultPreview(self: *Self) !vaxis.Window {
+        const root_win = self.vx.window();
+
+        const main_win = root_win.child(.{
+            .x_off = root_win.width / 2,
+            .width = .{ .limit = root_win.width / 2 },
+            .border = .{
+                .where = .all,
+                .style = .{ .fg = .{ .index = 7 } },
+                .glyphs = .single_square,
+            },
+        });
+
+        const title_seg: vaxis.Segment = .{
+            .text = "Option Preview",
+            .style = .{ .bold = true },
+        };
+        const title_win: vaxis.Window = main_win.child(.{ .height = .{ .limit = 1 } });
+
+        const centered: vaxis.Window = vaxis.widgets.alignment.center(title_win, title_seg.text.len, 2);
+        _ = try centered.printSegment(title_seg, .{});
+
+        return main_win;
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.text_input.deinit();
+        self.vx.deinit(self.allocator, self.tty.anyWriter());
+        self.tty.deinit();
+    }
+};
+
+pub fn optionSearchUI(allocator: Allocator) !void {
+    var app = try OptionSearchTUI.init(allocator);
+    defer app.deinit();
+
+    try app.run();
+}

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -260,6 +260,18 @@ pub fn concatStringsSep(allocator: Allocator, strings: []const []const u8, sep: 
     return result;
 }
 
+pub fn splitScalarAlloc(allocator: Allocator, input: []const u8, delim: u8) ![]const []const u8 {
+    var items = ArrayList([]const u8).init(allocator);
+    errdefer items.deinit();
+
+    var iter = mem.tokenizeScalar(u8, input, delim);
+    while (iter.next()) |token| {
+        try items.append(token);
+    }
+
+    return try items.toOwnedSlice();
+}
+
 /// Make a temporary directory; this is basically just the `mktemp`
 /// command but without actually invoking the `mktemp` command.
 pub fn mkTmpDir(allocator: Allocator, base: []const u8) ![]const u8 {

--- a/src/utils/search.zig
+++ b/src/utils/search.zig
@@ -50,31 +50,14 @@ pub fn rankCandidatesStruct(
     ranked: []CandidateStruct(T),
     candidates: []const T,
     tokens: []const []const u8,
-    // keep_order: bool,
     plain: bool,
     case_sensitive: bool,
 ) []CandidateStruct(T) {
     switch (@typeInfo(T)) {
-        .Struct => |struct_info| {
+        .Struct => |_| {
             if (!@hasField(T, field_name)) {
                 @compileError(@typeName(T) ++ " has no field named " ++ field_name);
             }
-            _ = struct_info;
-
-            // comptime var bruh: bool = false;
-            // inline for (struct_info.fields) |f| {
-            //     if (mem.eql(u8, f.name[0..], field_name)) {
-            //         bruh = true;
-            //         // if (@TypeOf(f.type) != []const u8) {
-            //         //     // @compileError("field type must be []const u8, got " ++ @typeName(f.type));
-            //         // }
-            //         break;
-            //     } else {}
-            // }
-
-            // if (!bruh) {
-            //     @compileError("no field found in struct type " ++ @typeName(T) ++ " with name " ++ field_name);
-            // }
         },
         else => @compileError("rankCandidatesStruct must take a struct type"),
     }
@@ -101,12 +84,6 @@ pub fn rankCandidatesStruct(
             index += 1;
         }
     }
-
-    // TODO: keep order param
-
-    // if (!keep_order) {
-    //     std.sort.block(Candidate, ranked[0..index], {}, sortCandidates);
-    // }
 
     return ranked[0..index];
 }


### PR DESCRIPTION
This adds an option search UI, similar to that at https://search.nixos.org/options.

This has the added ability of being able to view options that are currently available in the Nix config for that machine, and on the exact `nixpkgs` revision that config is based on, every single time. Plus, if `NIXOS_CONFIG` is changed to be a flake ref, any remote machine's options can be viewed as well! Neat.

Since https://search.nixos.org/options is based on an Elasticsearch cache, this would be much harder to accomplish there.

Tasks:
- [x] Search must be fast
- [x] Range highlighting for matching results
- [x] Option information preview (scrollable, because some descriptions can be quite long)
- [ ] (Maybe?) A preview of the option value itself

Closes #34.