### PR TITLE
feat(option): add option value preview window

### DIFF
--- a/src/option/ui.zig
+++ b/src/option/ui.zig
@@ -387,12 +387,8 @@ pub const OptionSearchTUI = struct {
             \\
             \\<Tab> moves to the option preview window.
             \\
-            \\
-        , .{});
-        try self.appendToBuffer(buf, "(This feature is coming soon)\n", .{ .italic = true });
-        try self.appendToBuffer(buf,
-            \\<Enter> will allow you to preview that option's current value, if it
-            \\is able to be evaluated. This will toggle the option value window.
+            \\<Enter> previews that option's current value, if it is able to be
+            \\evaluated. This will toggle the option value window.
             \\
             \\
             \\
@@ -406,10 +402,6 @@ pub const OptionSearchTUI = struct {
             \\
             \\<Tab> will move back to the input window for searching.
             \\
-            \\
-        , .{});
-        try self.appendToBuffer(buf, "(This feature is coming soon)\n", .{ .italic = true });
-        try self.appendToBuffer(buf,
             \\<Enter> will also evaluate the value, if possible.
             \\This will toggle the option value window.
             \\
@@ -418,7 +410,6 @@ pub const OptionSearchTUI = struct {
         , .{});
 
         try self.appendToBuffer(buf, "Option Value Window ", .{ .bold = true });
-        try self.appendToBuffer(buf, "(coming soon)\n", .{ .italic = true });
         try self.appendToBuffer(buf,
             \\Use the cursor keys or h, j, k, and l to scroll around.
             \\

--- a/src/option/ui.zig
+++ b/src/option/ui.zig
@@ -771,7 +771,7 @@ pub const OptionSearchTUI = struct {
                 const attr = try fmt.allocPrint(self.allocator, "config.{s}", .{opt_name});
                 defer self.allocator.free(attr);
 
-                try argv.appendSlice(&.{ "nix-instantiate", "--eval", "--strict", "<nixpkgs/nixos>", "-A", attr });
+                try argv.appendSlice(&.{ "nix-instantiate", "--eval", "<nixpkgs/nixos>", "-A", attr });
                 for (includes) |include| {
                     try argv.append(include);
                 }


### PR DESCRIPTION
This adds a new window that a user can toggle using `<Enter>`. This previews the option's value in the currently-loaded configuration.

This works for a lot of basic values, but unfortunately comes with some caveats:

- `nix eval` and `nix-instanatiate` do not format values, and their values cannot be passed into a Nix formatter such as `alejandra` or `nixfmt-rfc-style` due to the presence of lambdas and derivations. (Perhaps I should contribute pretty output for these commands to Nix upstream?)
- Some options are not able to be evaluated (such as `_module.args`).
- Error traces from these commands are not shown.

There is definitely a way to pretty-print these values, as demonstrated by the Nix REPL in Nix versions >= 2.21, but this is apparently not exposed to the `nix eval` and `nix-instantiate` commands. For now, I just wrap the values myself in the view buffer.