### PR TITLE
feat(option): sync non-interactive option behavior with interactive UI

### DIFF
--- a/src/option.zig
+++ b/src/option.zig
@@ -274,7 +274,7 @@ fn displayOption(opt: NixosOption, evaluated: EvaluatedValue) void {
             }
         }
         if (opt.readOnly) {
-            println(stdout, ansi.RED ++ ansi.ITALIC ++ "\nThis option is read-only." ++ ansi.RESET, .{});
+            println(stdout, ansi.YELLOW ++ "\nThis option is read-only." ++ ansi.RESET, .{});
         }
     } else {
         println(stdout, "Name\n{s}\n", .{opt.name});

--- a/src/option.zig
+++ b/src/option.zig
@@ -395,7 +395,7 @@ fn option(allocator: Allocator, args: OptionCommand) !void {
             flake_ref.inferSystemNameIfNeeded(&hostname_buf) catch return error.UnknownFlakeRef;
             break :blk .{ .flake = flake_ref };
         }
-        break :blk .{ .legacy = args.includes };
+        break :blk .{ .legacy = args.includes.items };
     };
 
     var options_filename_alloc = false;

--- a/src/option.zig
+++ b/src/option.zig
@@ -402,7 +402,7 @@ fn option(allocator: Allocator, args: OptionCommand) !void {
     }
 
     if (args.interactive) {
-        optionSearchUI(allocator, configuration, parsed_options.value) catch return OptionError.ResourceAccessFailed;
+        optionSearchUI(allocator, configuration, parsed_options.value, args.option) catch return OptionError.ResourceAccessFailed;
         return;
     }
 

--- a/src/option/ui.zig
+++ b/src/option/ui.zig
@@ -645,6 +645,11 @@ pub const OptionSearchTUI = struct {
             try self.appendToBuffer(buf, "\n", .{});
         }
 
+        if (opt.readOnly) {
+            try self.appendToBuffer(buf, "This option is read-only.", .{ .fg = .{ .index = 3 } });
+            try self.appendToBuffer(buf, "\n\n", .{});
+        }
+
         _ = self.option_view.draw(info_win, self.option_view_buf);
 
         return main_win;

--- a/src/option/ui.zig
+++ b/src/option/ui.zig
@@ -19,13 +19,13 @@ const TextViewBuffer = TextView.Buffer;
 const utils = @import("../utils.zig");
 const ansi = utils.ansi;
 const runCmd = utils.runCmd;
-const CandidateStruct = utils.search.CandidateStruct;
 
 const option_cmd = @import("../option.zig");
 const NixosOption = option_cmd.NixosOption;
-const OptionCandidate = CandidateStruct(NixosOption);
+const OptionCandidate = option_cmd.OptionCandidate;
 const EvaluatedValue = option_cmd.EvaluatedValue;
 const ConfigType = option_cmd.ConfigType;
+const compareOptionCandidates = option_cmd.compareOptionCandidates;
 
 const zf = @import("zf");
 
@@ -34,24 +34,6 @@ const Event = union(enum) {
     winsize: vaxis.Winsize,
     value_changed,
 };
-
-fn compareOptionCandidates(_: void, a: OptionCandidate, b: OptionCandidate) bool {
-    if (a.rank < b.rank) return true;
-    if (a.rank > b.rank) return false;
-
-    const aa = a.value.name;
-    const bb = b.value.name;
-
-    if (aa.len < bb.len) return true;
-    if (aa.len > bb.len) return false;
-
-    for (aa, 0..) |c, i| {
-        if (c < bb[i]) return true;
-        if (c > bb[i]) return false;
-    }
-
-    return false;
-}
 
 pub const OptionSearchTUI = struct {
     allocator: Allocator,
@@ -99,7 +81,7 @@ pub const OptionSearchTUI = struct {
             try text_input.insertSliceAtCursor(query);
         }
 
-        const candidate_filter_buf = try allocator.alloc(CandidateStruct(NixosOption), options.len);
+        const candidate_filter_buf = try allocator.alloc(OptionCandidate, options.len);
         errdefer allocator.free(candidate_filter_buf);
 
         const initial_results = blk: {


### PR DESCRIPTION
There were some discrepancies between how the UI behaved vs. how the command that just outputted to `stdout` behaved.

This synchronizes the two, and adds some extra improvements and refactors to the non-interactive command as well.