### PR TITLE
feat(option): render description markdown

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -87,6 +87,7 @@ fn nixosExecutable(b: *Build, opts: struct {
     const zf_package = b.dependency("zf", common_dep_options);
     const zeit_package = b.dependency("zeit", common_dep_options);
     const vaxis_package = b.dependency("vaxis", common_dep_options);
+    const koino_package = b.dependency("koino", common_dep_options);
 
     const exe = b.addExecutable(.{
         .name = "nixos",
@@ -99,6 +100,7 @@ fn nixosExecutable(b: *Build, opts: struct {
     exe.root_module.addImport("zf", zf_package.module("zf"));
     exe.root_module.addImport("zeit", zeit_package.module("zeit"));
     exe.root_module.addImport("vaxis", vaxis_package.module("vaxis"));
+    exe.root_module.addImport("koino", koino_package.module("koino"));
 
     exe.root_module.addOptions("options", opts.options);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -32,5 +32,9 @@
             .url = "https://github.com/rockorager/libvaxis/archive/d36ab043caf7cbb24cae1bd0346dd6b654df0653.tar.gz",
             .hash = "12206c252ee00b9dd0214989dfa35a6eea29ac7d65d4053817f161f4c23b6e09dd89",
         },
+        .koino = .{
+            .url = "https://github.com/kivikakk/koino/archive/0151bb37714d93688f31e3d7a3d0369106818f26.tar.gz",
+            .hash = "122055057fe62c0a8bcccb3c36a23115db58a185af2c18dd41d0bb4ac083f519ad5d",
+        },
     },
 }

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -47,6 +47,8 @@ extra_config = ""
 # above 1; higher scores will give less relevant results, while smaller scores
 # will be more strict in matching.
 max_rank = 3.00
+# Attempt to prettify option descriptions with colors and formatting.
+prettify = true
 
 # Extra configuration to append to `configuration.nix`,
 # as structured key-value pairs

--- a/package.nix
+++ b/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
       inherit stdenv zig;
       name = pname;
       src = ./.;
-      depsHash = "sha256-u1J43hMWFZaN9MSMfEhjOZEGFxPGUuJgnuedeZYgk6s=";
+      depsHash = "sha256-TNiG5pxvESsAWCAz4BEwie+CMO6ZoNKdnm3qo6wNc4c=";
     };
   in ''
     mkdir -p .cache

--- a/src/config.zig
+++ b/src/config.zig
@@ -89,6 +89,7 @@ pub const Config = struct {
     no_confirm: bool = false,
     option: struct {
         max_rank: f64 = 3.00,
+        prettify: bool = true,
     } = .{},
     use_nvd: bool = false,
 };

--- a/src/log.zig
+++ b/src/log.zig
@@ -48,7 +48,7 @@ pub fn step(comptime fmt: []const u8, args: anytype) void {
 /// Pretty-print a command that will be ran.
 pub fn cmd(argv: []const []const u8) void {
     if (Constants.use_color) {
-        print(ansi.BR_BLUE, .{});
+        print(ansi.BLUE, .{});
     }
 
     print("$ ", .{});

--- a/src/option.zig
+++ b/src/option.zig
@@ -263,6 +263,16 @@ fn displayOption(allocator: Allocator, opt: NixosOption, evaluated: EvaluatedVal
     const description = blk: {
         if (opt.description) |d| {
             const stripped = stripInlineCodeAnnotations(d, desc_buf);
+
+            // Skip rendering if NO_COLOR is set. This isn't worth the time
+            // to try and parse and format properly without the ANSI escapes.
+            //
+            // If a generic writer is brought in that sanitizes all ANSI
+            // codes, then this can be revisited.
+            if (!Constants.use_color) {
+                break :blk mem.trim(u8, stripped, "\n");
+            }
+
             const rendered = utils.markdown.renderMarkdownANSI(allocator, stripped) catch |err| {
                 desc_alloc = true;
                 break :blk try fmt.allocPrint(allocator, "unable to render description: {s}", .{@errorName(err)});

--- a/src/option.zig
+++ b/src/option.zig
@@ -282,24 +282,29 @@ fn displayOption(allocator: Allocator, opt: NixosOption, evaluated: EvaluatedVal
         if (opt.default) |d| {
             break :blk mem.trim(u8, d.text, "\n ");
         }
-        break :blk if (Constants.use_color)
-            ansi.ITALIC ++ "(none)" ++ ansi.RESET
-        else
-            "(none)";
+        break :blk "(none)";
     };
     const example = if (opt.example) |e| mem.trim(u8, e.text, "\n ") else null;
 
     if (Constants.use_color) {
         println(stdout, ansi.BOLD ++ "Name\n" ++ ansi.RESET ++ "{s}\n", .{opt.name});
         println(stdout, ansi.BOLD ++ "Description\n" ++ ansi.RESET ++ "{s}\n", .{description});
-        println(stdout, ansi.BOLD ++ "Type\n" ++ ansi.RESET ++ "{s}\n", .{opt.type});
+        println(stdout, ansi.BOLD ++ "Type\n" ++ ansi.RESET ++ ansi.ITALIC ++ "{s}\n" ++ ansi.RESET, .{opt.type});
         println(stdout, ansi.BOLD ++ "Value" ++ ansi.RESET, .{});
         if (std.meta.activeTag(evaluated) == .success) {
             println(stdout, "{s}\n", .{evaluated.success});
         } else {
             println(stdout, ansi.RED ++ "error: {s}\n" ++ ansi.RESET, .{evaluated.@"error"});
         }
-        println(stdout, ansi.BOLD ++ "Default\n" ++ ansi.RESET ++ "{s}\n", .{default});
+
+        println(stdout, ansi.BOLD ++ "Default" ++ ansi.RESET, .{});
+        if (opt.default) |_| {
+            println(stdout, ansi.WHITE ++ "{s}" ++ ansi.RESET, .{default});
+        } else {
+            println(stdout, ansi.ITALIC ++ "(none)" ++ ansi.RESET, .{});
+        }
+        println(stdout, "", .{});
+
         if (example) |e| {
             println(stdout, ansi.BOLD ++ "Example\n" ++ ansi.RESET ++ "{s}\n", .{e});
         }

--- a/src/option.zig
+++ b/src/option.zig
@@ -16,6 +16,8 @@ const argIs = argparse.argIs;
 const argError = argparse.argError;
 const getNextArgs = argparse.getNextArgs;
 
+const config = @import("config.zig");
+
 const Constants = @import("constants.zig");
 
 const log = @import("log.zig");
@@ -252,6 +254,8 @@ pub fn stripInlineCodeAnnotations(slice: []const u8, buf: []u8) []const u8 {
 }
 
 fn displayOption(allocator: Allocator, opt: NixosOption, evaluated: EvaluatedValue) !void {
+    const c = config.getConfig();
+
     const stdout = io.getStdOut().writer();
 
     const desc_buf = try allocator.alloc(u8, if (opt.description) |d| d.len else 0);
@@ -264,12 +268,13 @@ fn displayOption(allocator: Allocator, opt: NixosOption, evaluated: EvaluatedVal
         if (opt.description) |d| {
             const stripped = stripInlineCodeAnnotations(d, desc_buf);
 
-            // Skip rendering if NO_COLOR is set. This isn't worth the time
+            // Skip rendering if NO_COLOR is set, or if prettifying
+            // is disabled in the config. This isn't worth the time
             // to try and parse and format properly without the ANSI escapes.
             //
             // If a generic writer is brought in that sanitizes all ANSI
             // codes, then this can be revisited.
-            if (!Constants.use_color) {
+            if (!Constants.use_color or !c.option.prettify) {
                 break :blk mem.trim(u8, stripped, "\n");
             }
 

--- a/src/option/ui.zig
+++ b/src/option/ui.zig
@@ -19,6 +19,7 @@ const TextViewBuffer = TextView.Buffer;
 const utils = @import("../utils.zig");
 const ansi = utils.ansi;
 const runCmd = utils.runCmd;
+const appendToBuffer = utils.vaxis.appendToTextBuffer;
 
 const option_cmd = @import("../option.zig");
 const NixosOption = option_cmd.NixosOption;
@@ -329,12 +330,12 @@ pub const OptionSearchTUI = struct {
         main_win.hideCursor();
 
         const buf = &self.help_view_buf;
-        try self.appendToBuffer(buf, "nixos option -i", .{ .fg = .{ .index = 7 } });
-        try self.appendToBuffer(buf, " is a tool designed to help search through available\n", .{});
-        try self.appendToBuffer(buf, "options on a given NixOS system with ease.\n\n", .{});
+        try appendToBuffer(self.allocator, self.vx, buf, "nixos option -i", .{ .fg = .{ .index = 7 } });
+        try appendToBuffer(self.allocator, self.vx, buf, " is a tool designed to help search through available\n", .{});
+        try appendToBuffer(self.allocator, self.vx, buf, "options on a given NixOS system with ease.\n\n", .{});
 
-        try self.appendToBuffer(buf, "Basic Features\n", .{ .bold = true });
-        try self.appendToBuffer(buf,
+        try appendToBuffer(self.allocator, self.vx, buf, "Basic Features\n", .{ .bold = true });
+        try appendToBuffer(self.allocator, self.vx, buf,
             \\A purple border means that a given window is active. If a window
             \\is active, then its keybinds will work.
             \\
@@ -348,8 +349,8 @@ pub const OptionSearchTUI = struct {
             \\
         , .{});
 
-        try self.appendToBuffer(buf, "Help Window\n", .{ .bold = true });
-        try self.appendToBuffer(buf,
+        try appendToBuffer(self.allocator, self.vx, buf, "Help Window\n", .{ .bold = true });
+        try appendToBuffer(self.allocator, self.vx, buf,
             \\Use the cursor keys or h, j, k, and l to scroll around.
             \\
             \\<Esc> or q will close this help window.
@@ -358,8 +359,8 @@ pub const OptionSearchTUI = struct {
             \\
         , .{});
 
-        try self.appendToBuffer(buf, "Option Input Window\n", .{ .bold = true });
-        try self.appendToBuffer(buf,
+        try appendToBuffer(self.allocator, self.vx, buf, "Option Input Window\n", .{ .bold = true });
+        try appendToBuffer(self.allocator, self.vx, buf,
             \\Type anything into the input box and all available options that
             \\match will be filtered into a list. Scroll this list with the up
             \\or down cursor keys, and the information for that option will show
@@ -374,8 +375,8 @@ pub const OptionSearchTUI = struct {
             \\
         , .{});
 
-        try self.appendToBuffer(buf, "Option Preview Window\n", .{ .bold = true });
-        try self.appendToBuffer(buf,
+        try appendToBuffer(self.allocator, self.vx, buf, "Option Preview Window\n", .{ .bold = true });
+        try appendToBuffer(self.allocator, self.vx, buf,
             \\Use the cursor keys or h, j, k, and l to scroll around.
             \\
             \\The input box is not updated when this window is active.
@@ -389,8 +390,8 @@ pub const OptionSearchTUI = struct {
             \\
         , .{});
 
-        try self.appendToBuffer(buf, "Option Value Window ", .{ .bold = true });
-        try self.appendToBuffer(buf,
+        try appendToBuffer(self.allocator, self.vx, buf, "Option Value Window ", .{ .bold = true });
+        try appendToBuffer(self.allocator, self.vx, buf,
             \\Use the cursor keys or h, j, k, and l to scroll around.
             \\
             \\<Esc> or q will close this window.
@@ -607,50 +608,50 @@ pub const OptionSearchTUI = struct {
         self.option_view_buf.clear(self.allocator);
 
         const buf = &self.option_view_buf;
-        try self.appendToBuffer(buf, "Name\n", .{ .bold = true });
-        try self.appendToBuffer(buf, opt.name, .{});
-        try self.appendToBuffer(buf, "\n\n", .{});
+        try appendToBuffer(self.allocator, self.vx, buf, "Name\n", .{ .bold = true });
+        try appendToBuffer(self.allocator, self.vx, buf, opt.name, .{});
+        try appendToBuffer(self.allocator, self.vx, buf, "\n\n", .{});
 
         const desc_buf = try allocator.alloc(u8, if (opt.description) |d| d.len else 0);
 
-        try self.appendToBuffer(buf, "Description\n", .{ .bold = true });
+        try appendToBuffer(self.allocator, self.vx, buf, "Description\n", .{ .bold = true });
         if (opt.description) |d| {
             const desc = option_cmd.stripInlineCodeAnnotations(d, desc_buf);
-            try self.appendToBuffer(buf, mem.trim(u8, desc, "\n"), .{});
+            try appendToBuffer(self.allocator, self.vx, buf, mem.trim(u8, desc, "\n"), .{});
         } else {
-            try self.appendToBuffer(buf, "(none)", .{ .italic = true });
+            try appendToBuffer(self.allocator, self.vx, buf, "(none)", .{ .italic = true });
         }
-        try self.appendToBuffer(buf, "\n\n", .{});
+        try appendToBuffer(self.allocator, self.vx, buf, "\n\n", .{});
 
-        try self.appendToBuffer(buf, "Type\n", .{ .bold = true });
-        try self.appendToBuffer(buf, opt.type, .{ .italic = true });
-        try self.appendToBuffer(buf, "\n\n", .{});
+        try appendToBuffer(self.allocator, self.vx, buf, "Type\n", .{ .bold = true });
+        try appendToBuffer(self.allocator, self.vx, buf, opt.type, .{ .italic = true });
+        try appendToBuffer(self.allocator, self.vx, buf, "\n\n", .{});
 
-        try self.appendToBuffer(buf, "Default\n", .{ .bold = true });
+        try appendToBuffer(self.allocator, self.vx, buf, "Default\n", .{ .bold = true });
         if (opt.default) |d| {
-            try self.appendToBuffer(buf, mem.trim(u8, d.text, "\n"), .{ .fg = .{ .index = 7 } });
+            try appendToBuffer(self.allocator, self.vx, buf, mem.trim(u8, d.text, "\n"), .{ .fg = .{ .index = 7 } });
         } else {
-            try self.appendToBuffer(buf, "(none)", .{ .italic = true });
+            try appendToBuffer(self.allocator, self.vx, buf, "(none)", .{ .italic = true });
         }
-        try self.appendToBuffer(buf, "\n\n", .{});
+        try appendToBuffer(self.allocator, self.vx, buf, "\n\n", .{});
 
         if (opt.example) |e| {
-            try self.appendToBuffer(buf, "Example\n", .{ .bold = true });
-            try self.appendToBuffer(buf, mem.trim(u8, e.text, "\n"), .{ .fg = .{ .index = 7 } });
-            try self.appendToBuffer(buf, "\n\n", .{});
+            try appendToBuffer(self.allocator, self.vx, buf, "Example\n", .{ .bold = true });
+            try appendToBuffer(self.allocator, self.vx, buf, mem.trim(u8, e.text, "\n"), .{ .fg = .{ .index = 7 } });
+            try appendToBuffer(self.allocator, self.vx, buf, "\n\n", .{});
         }
 
         if (opt.declarations.len > 0) {
-            try self.appendToBuffer(buf, "Declared In\n", .{ .bold = true });
+            try appendToBuffer(self.allocator, self.vx, buf, "Declared In\n", .{ .bold = true });
             for (opt.declarations) |decl| {
-                try self.appendToBuffer(buf, try fmt.allocPrint(allocator, "  - {s}\n", .{decl}), .{ .italic = true });
+                try appendToBuffer(self.allocator, self.vx, buf, try fmt.allocPrint(allocator, "  - {s}\n", .{decl}), .{ .italic = true });
             }
-            try self.appendToBuffer(buf, "\n", .{});
+            try appendToBuffer(self.allocator, self.vx, buf, "\n", .{});
         }
 
         if (opt.readOnly) {
-            try self.appendToBuffer(buf, "This option is read-only.", .{ .fg = .{ .index = 3 } });
-            try self.appendToBuffer(buf, "\n\n", .{});
+            try appendToBuffer(self.allocator, self.vx, buf, "This option is read-only.", .{ .fg = .{ .index = 3 } });
+            try appendToBuffer(self.allocator, self.vx, buf, "\n\n", .{});
         }
 
         _ = self.option_view.draw(info_win, self.option_view_buf);
@@ -694,40 +695,24 @@ pub const OptionSearchTUI = struct {
         });
 
         switch (self.option_eval_value) {
-            .loading => try self.appendToBuffer(buf, "Loading...", .{}),
+            .loading => try appendToBuffer(self.allocator, self.vx, buf, "Loading...", .{}),
             .success => |value| {
                 // Nix outputs the evaluated value on a single line. This
                 // wraps the value to the window.
                 var i: usize = 0;
                 while (i < value.len -| info_win.width) : (i += info_win.width) {
                     const end = i + info_win.width - 1;
-                    try self.appendToBuffer(buf, value[i..end], .{ .fg = .{ .index = 7 } });
-                    try self.appendToBuffer(buf, "\n", .{});
+                    try appendToBuffer(self.allocator, self.vx, buf, value[i..end], .{ .fg = .{ .index = 7 } });
+                    try appendToBuffer(self.allocator, self.vx, buf, "\n", .{});
                 }
                 if (i < value.len) {
-                    try self.appendToBuffer(buf, value[i..], .{ .fg = .{ .index = 7 } });
+                    try appendToBuffer(self.allocator, self.vx, buf, value[i..], .{ .fg = .{ .index = 7 } });
                 }
             },
-            .@"error" => |message| try self.appendToBuffer(buf, message, .{ .fg = .{ .index = 1 } }),
+            .@"error" => |message| try appendToBuffer(self.allocator, self.vx, buf, message, .{ .fg = .{ .index = 1 } }),
         }
 
         self.value_view.draw(info_win, self.value_view_buf);
-    }
-
-    fn appendToBuffer(self: *Self, buf: *TextViewBuffer, content: []const u8, style: vaxis.Style) !void {
-        const begin = buf.content.items.len;
-        const end = begin + content.len + 1;
-
-        try buf.append(self.allocator, .{
-            .bytes = content,
-            .gd = &self.vx.unicode.grapheme_data,
-            .wd = &self.vx.unicode.width_data,
-        });
-        try buf.updateStyle(self.allocator, .{
-            .begin = begin,
-            .end = end,
-            .style = style,
-        });
     }
 
     fn evaluateOptionValue(self: *Self, orig_counter: usize, loop: *vaxis.Loop(Event)) !void {

--- a/src/option/ui.zig
+++ b/src/option/ui.zig
@@ -611,9 +611,12 @@ pub const OptionSearchTUI = struct {
         try self.appendToBuffer(buf, opt.name, .{});
         try self.appendToBuffer(buf, "\n\n", .{});
 
+        const desc_buf = try allocator.alloc(u8, if (opt.description) |d| d.len else 0);
+
         try self.appendToBuffer(buf, "Description\n", .{ .bold = true });
         if (opt.description) |d| {
-            try self.appendToBuffer(buf, mem.trim(u8, d, "\n"), .{});
+            const desc = option_cmd.stripInlineCodeAnnotations(d, desc_buf);
+            try self.appendToBuffer(buf, mem.trim(u8, desc, "\n"), .{});
         } else {
             try self.appendToBuffer(buf, "(none)", .{ .italic = true });
         }

--- a/src/option/ui.zig
+++ b/src/option/ui.zig
@@ -19,7 +19,8 @@ const TextViewBuffer = TextView.Buffer;
 const utils = @import("../utils.zig");
 const ansi = utils.ansi;
 const runCmd = utils.runCmd;
-const appendToBuffer = utils.vaxis.appendToTextBuffer;
+const appendToTextBuffer = utils.vaxis.appendToTextBuffer;
+const appendToTextBufferANSI = utils.vaxis.appendToTextBufferANSI;
 
 const option_cmd = @import("../option.zig");
 const NixosOption = option_cmd.NixosOption;
@@ -330,12 +331,12 @@ pub const OptionSearchTUI = struct {
         main_win.hideCursor();
 
         const buf = &self.help_view_buf;
-        try appendToBuffer(self.allocator, self.vx, buf, "nixos option -i", .{ .fg = .{ .index = 7 } });
-        try appendToBuffer(self.allocator, self.vx, buf, " is a tool designed to help search through available\n", .{});
-        try appendToBuffer(self.allocator, self.vx, buf, "options on a given NixOS system with ease.\n\n", .{});
+        try appendToTextBuffer(self.allocator, self.vx, buf, "nixos option -i", .{ .fg = .{ .index = 7 } });
+        try appendToTextBuffer(self.allocator, self.vx, buf, " is a tool designed to help search through available\n", .{});
+        try appendToTextBuffer(self.allocator, self.vx, buf, "options on a given NixOS system with ease.\n\n", .{});
 
-        try appendToBuffer(self.allocator, self.vx, buf, "Basic Features\n", .{ .bold = true });
-        try appendToBuffer(self.allocator, self.vx, buf,
+        try appendToTextBuffer(self.allocator, self.vx, buf, "Basic Features\n", .{ .bold = true });
+        try appendToTextBuffer(self.allocator, self.vx, buf,
             \\A purple border means that a given window is active. If a window
             \\is active, then its keybinds will work.
             \\
@@ -349,8 +350,8 @@ pub const OptionSearchTUI = struct {
             \\
         , .{});
 
-        try appendToBuffer(self.allocator, self.vx, buf, "Help Window\n", .{ .bold = true });
-        try appendToBuffer(self.allocator, self.vx, buf,
+        try appendToTextBuffer(self.allocator, self.vx, buf, "Help Window\n", .{ .bold = true });
+        try appendToTextBuffer(self.allocator, self.vx, buf,
             \\Use the cursor keys or h, j, k, and l to scroll around.
             \\
             \\<Esc> or q will close this help window.
@@ -359,8 +360,8 @@ pub const OptionSearchTUI = struct {
             \\
         , .{});
 
-        try appendToBuffer(self.allocator, self.vx, buf, "Option Input Window\n", .{ .bold = true });
-        try appendToBuffer(self.allocator, self.vx, buf,
+        try appendToTextBuffer(self.allocator, self.vx, buf, "Option Input Window\n", .{ .bold = true });
+        try appendToTextBuffer(self.allocator, self.vx, buf,
             \\Type anything into the input box and all available options that
             \\match will be filtered into a list. Scroll this list with the up
             \\or down cursor keys, and the information for that option will show
@@ -375,8 +376,8 @@ pub const OptionSearchTUI = struct {
             \\
         , .{});
 
-        try appendToBuffer(self.allocator, self.vx, buf, "Option Preview Window\n", .{ .bold = true });
-        try appendToBuffer(self.allocator, self.vx, buf,
+        try appendToTextBuffer(self.allocator, self.vx, buf, "Option Preview Window\n", .{ .bold = true });
+        try appendToTextBuffer(self.allocator, self.vx, buf,
             \\Use the cursor keys or h, j, k, and l to scroll around.
             \\
             \\The input box is not updated when this window is active.
@@ -390,8 +391,8 @@ pub const OptionSearchTUI = struct {
             \\
         , .{});
 
-        try appendToBuffer(self.allocator, self.vx, buf, "Option Value Window ", .{ .bold = true });
-        try appendToBuffer(self.allocator, self.vx, buf,
+        try appendToTextBuffer(self.allocator, self.vx, buf, "Option Value Window ", .{ .bold = true });
+        try appendToTextBuffer(self.allocator, self.vx, buf,
             \\Use the cursor keys or h, j, k, and l to scroll around.
             \\
             \\<Esc> or q will close this window.
@@ -608,50 +609,55 @@ pub const OptionSearchTUI = struct {
         self.option_view_buf.clear(self.allocator);
 
         const buf = &self.option_view_buf;
-        try appendToBuffer(self.allocator, self.vx, buf, "Name\n", .{ .bold = true });
-        try appendToBuffer(self.allocator, self.vx, buf, opt.name, .{});
-        try appendToBuffer(self.allocator, self.vx, buf, "\n\n", .{});
+        try appendToTextBuffer(self.allocator, self.vx, buf, "Name\n", .{ .bold = true });
+        try appendToTextBuffer(self.allocator, self.vx, buf, opt.name, .{});
+        try appendToTextBuffer(self.allocator, self.vx, buf, "\n\n", .{});
 
         const desc_buf = try allocator.alloc(u8, if (opt.description) |d| d.len else 0);
 
-        try appendToBuffer(self.allocator, self.vx, buf, "Description\n", .{ .bold = true });
-        if (opt.description) |d| {
-            const desc = option_cmd.stripInlineCodeAnnotations(d, desc_buf);
-            try appendToBuffer(self.allocator, self.vx, buf, mem.trim(u8, desc, "\n"), .{});
+        try appendToTextBuffer(self.allocator, self.vx, buf, "Description\n", .{ .bold = true });
+        if (opt.description) |d| desc: {
+            const desc_raw = option_cmd.stripInlineCodeAnnotations(d, desc_buf);
+            const rendered = utils.markdown.renderMarkdownANSI(allocator, desc_raw) catch {
+                // Use the raw description without rendering if it somehow fails.
+                try appendToTextBuffer(self.allocator, self.vx, buf, desc_raw, .{});
+                break :desc;
+            };
+            try appendToTextBufferANSI(self.allocator, self.vx, buf, mem.trim(u8, rendered, "\n "));
         } else {
-            try appendToBuffer(self.allocator, self.vx, buf, "(none)", .{ .italic = true });
+            try appendToTextBuffer(self.allocator, self.vx, buf, "(none)", .{ .italic = true });
         }
-        try appendToBuffer(self.allocator, self.vx, buf, "\n\n", .{});
+        try appendToTextBuffer(self.allocator, self.vx, buf, "\n\n", .{});
 
-        try appendToBuffer(self.allocator, self.vx, buf, "Type\n", .{ .bold = true });
-        try appendToBuffer(self.allocator, self.vx, buf, opt.type, .{ .italic = true });
-        try appendToBuffer(self.allocator, self.vx, buf, "\n\n", .{});
+        try appendToTextBuffer(self.allocator, self.vx, buf, "Type\n", .{ .bold = true });
+        try appendToTextBuffer(self.allocator, self.vx, buf, opt.type, .{ .italic = true });
+        try appendToTextBuffer(self.allocator, self.vx, buf, "\n\n", .{});
 
-        try appendToBuffer(self.allocator, self.vx, buf, "Default\n", .{ .bold = true });
+        try appendToTextBuffer(self.allocator, self.vx, buf, "Default\n", .{ .bold = true });
         if (opt.default) |d| {
-            try appendToBuffer(self.allocator, self.vx, buf, mem.trim(u8, d.text, "\n"), .{ .fg = .{ .index = 7 } });
+            try appendToTextBuffer(self.allocator, self.vx, buf, mem.trim(u8, d.text, "\n"), .{ .fg = .{ .index = 7 } });
         } else {
-            try appendToBuffer(self.allocator, self.vx, buf, "(none)", .{ .italic = true });
+            try appendToTextBuffer(self.allocator, self.vx, buf, "(none)", .{ .italic = true });
         }
-        try appendToBuffer(self.allocator, self.vx, buf, "\n\n", .{});
+        try appendToTextBuffer(self.allocator, self.vx, buf, "\n\n", .{});
 
         if (opt.example) |e| {
-            try appendToBuffer(self.allocator, self.vx, buf, "Example\n", .{ .bold = true });
-            try appendToBuffer(self.allocator, self.vx, buf, mem.trim(u8, e.text, "\n"), .{ .fg = .{ .index = 7 } });
-            try appendToBuffer(self.allocator, self.vx, buf, "\n\n", .{});
+            try appendToTextBuffer(self.allocator, self.vx, buf, "Example\n", .{ .bold = true });
+            try appendToTextBuffer(self.allocator, self.vx, buf, mem.trim(u8, e.text, "\n"), .{ .fg = .{ .index = 7 } });
+            try appendToTextBuffer(self.allocator, self.vx, buf, "\n\n", .{});
         }
 
         if (opt.declarations.len > 0) {
-            try appendToBuffer(self.allocator, self.vx, buf, "Declared In\n", .{ .bold = true });
+            try appendToTextBuffer(self.allocator, self.vx, buf, "Declared In\n", .{ .bold = true });
             for (opt.declarations) |decl| {
-                try appendToBuffer(self.allocator, self.vx, buf, try fmt.allocPrint(allocator, "  - {s}\n", .{decl}), .{ .italic = true });
+                try appendToTextBuffer(self.allocator, self.vx, buf, try fmt.allocPrint(allocator, "  - {s}\n", .{decl}), .{ .italic = true });
             }
-            try appendToBuffer(self.allocator, self.vx, buf, "\n", .{});
+            try appendToTextBuffer(self.allocator, self.vx, buf, "\n", .{});
         }
 
         if (opt.readOnly) {
-            try appendToBuffer(self.allocator, self.vx, buf, "This option is read-only.", .{ .fg = .{ .index = 3 } });
-            try appendToBuffer(self.allocator, self.vx, buf, "\n\n", .{});
+            try appendToTextBuffer(self.allocator, self.vx, buf, "This option is read-only.", .{ .fg = .{ .index = 3 } });
+            try appendToTextBuffer(self.allocator, self.vx, buf, "\n\n", .{});
         }
 
         _ = self.option_view.draw(info_win, self.option_view_buf);
@@ -695,21 +701,21 @@ pub const OptionSearchTUI = struct {
         });
 
         switch (self.option_eval_value) {
-            .loading => try appendToBuffer(self.allocator, self.vx, buf, "Loading...", .{}),
+            .loading => try appendToTextBuffer(self.allocator, self.vx, buf, "Loading...", .{}),
             .success => |value| {
                 // Nix outputs the evaluated value on a single line. This
                 // wraps the value to the window.
                 var i: usize = 0;
                 while (i < value.len -| info_win.width) : (i += info_win.width) {
                     const end = i + info_win.width - 1;
-                    try appendToBuffer(self.allocator, self.vx, buf, value[i..end], .{ .fg = .{ .index = 7 } });
-                    try appendToBuffer(self.allocator, self.vx, buf, "\n", .{});
+                    try appendToTextBuffer(self.allocator, self.vx, buf, value[i..end], .{ .fg = .{ .index = 7 } });
+                    try appendToTextBuffer(self.allocator, self.vx, buf, "\n", .{});
                 }
                 if (i < value.len) {
-                    try appendToBuffer(self.allocator, self.vx, buf, value[i..], .{ .fg = .{ .index = 7 } });
+                    try appendToTextBuffer(self.allocator, self.vx, buf, value[i..], .{ .fg = .{ .index = 7 } });
                 }
             },
-            .@"error" => |message| try appendToBuffer(self.allocator, self.vx, buf, message, .{ .fg = .{ .index = 1 } }),
+            .@"error" => |message| try appendToTextBuffer(self.allocator, self.vx, buf, message, .{ .fg = .{ .index = 1 } }),
         }
 
         self.value_view.draw(info_win, self.value_view_buf);

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -434,3 +434,4 @@ pub const search = @import("utils/search.zig");
 pub const generation = @import("utils/generation.zig");
 pub const ansi = @import("utils/ansi.zig");
 pub const time = @import("utils/time.zig");
+pub const markdown = @import("utils/markdown.zig");

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -435,3 +435,4 @@ pub const generation = @import("utils/generation.zig");
 pub const ansi = @import("utils/ansi.zig");
 pub const time = @import("utils/time.zig");
 pub const markdown = @import("utils/markdown.zig");
+pub const vaxis = @import("utils/vaxis.zig");

--- a/src/utils/ansi.zig
+++ b/src/utils/ansi.zig
@@ -8,15 +8,6 @@ pub const CYAN = "\x1B[36m";
 pub const WHITE = "\x1B[37m";
 pub const DEFAULT = "\x1B[39m";
 
-pub const BR_BLACK = "\x1B[90m";
-pub const BR_RED = "\x1B[91m";
-pub const BR_GREEN = "\x1B[92m";
-pub const BR_YELLOW = "\x1B[93m";
-pub const BR_BLUE = "\x1B[94m";
-pub const BR_MAGENTA = "\x1B[95m";
-pub const BR_CYAN = "\x1B[96m";
-pub const BR_WHITE = "\x1B[97m";
-
 pub const RESET = "\x1B[0m";
 pub const BOLD = "\x1B[1m";
 pub const DIM = "\x1B[2m";

--- a/src/utils/ansi.zig
+++ b/src/utils/ansi.zig
@@ -6,6 +6,7 @@ pub const BLUE = "\x1B[34m";
 pub const MAGENTA = "\x1B[35m";
 pub const CYAN = "\x1B[36m";
 pub const WHITE = "\x1B[37m";
+pub const DEFAULT = "\x1B[39m";
 
 pub const BR_BLACK = "\x1B[90m";
 pub const BR_RED = "\x1B[91m";
@@ -18,8 +19,16 @@ pub const BR_WHITE = "\x1B[97m";
 
 pub const RESET = "\x1B[0m";
 pub const BOLD = "\x1B[1m";
+pub const DIM = "\x1B[2m";
 pub const ITALIC = "\x1B[3m";
 pub const UNDERLINE = "\x1B[4m";
+pub const STRIKE = "\x1B[9m";
+
+pub const R_BOLD = "\x1B[21m";
+pub const R_DIM = "\x1B[22m";
+pub const R_ITALIC = "\x1B[23m";
+pub const R_UNDERLINE = "\x1B[24m";
+pub const R_STRIKE = "\x1B[29m";
 
 pub const CLEAR = "\x1B[2J";
 pub const MV_TOP_LEFT = "\x1B[H";

--- a/src/utils/markdown.zig
+++ b/src/utils/markdown.zig
@@ -1,0 +1,304 @@
+const std = @import("std");
+const ascii = std.ascii;
+const mem = std.mem;
+const Allocator = mem.Allocator;
+const ArrayList = std.ArrayList;
+
+const ansi = @import("./ansi.zig");
+
+const log = @import("../log.zig");
+
+const koino = @import("koino");
+const MDParser = koino.parser.Parser;
+const Options = koino.Options;
+const AstNode = koino.nodes.AstNode;
+
+pub fn renderMarkdownANSI(allocator: Allocator, slice: []const u8) ![]const u8 {
+    var p = try MDParser.init(allocator, .{});
+    try p.feed(slice);
+
+    var doc = try p.finish();
+    p.deinit();
+
+    defer doc.deinit();
+
+    var result = ArrayList(u8).init(allocator);
+    const writer = result.writer();
+
+    var formatter = makeANSIFormatter(writer, allocator, p.options);
+
+    try formatter.format(doc, false);
+
+    return result.toOwnedSlice();
+}
+
+pub fn makeANSIFormatter(writer: anytype, allocator: std.mem.Allocator, options: Options) ANSIFormatter(@TypeOf(writer)) {
+    return ANSIFormatter(@TypeOf(writer)).init(writer, allocator, options);
+}
+
+pub fn ANSIFormatter(comptime Writer: type) type {
+    return struct {
+        writer: Writer,
+        allocator: std.mem.Allocator,
+        options: Options,
+        last_was_lf: bool = true,
+
+        const Self = @This();
+
+        pub fn init(writer: Writer, allocator: std.mem.Allocator, options: Options) Self {
+            return .{
+                .writer = writer,
+                .allocator = allocator,
+                .options = options,
+            };
+        }
+
+        fn cr(self: *Self) !void {
+            if (!self.last_was_lf) {
+                try self.writeAll("\n");
+            }
+        }
+
+        pub fn writeAll(self: *Self, s: []const u8) !void {
+            if (s.len == 0) {
+                return;
+            }
+            try self.writer.writeAll(s);
+            self.last_was_lf = s[s.len - 1] == '\n';
+        }
+
+        pub fn format(self: *Self, input_node: *AstNode, plain: bool) !void {
+            const Phase = enum { Pre, Post };
+            const StackEntry = struct {
+                node: *AstNode,
+                plain: bool,
+                phase: Phase,
+            };
+
+            var stack = ArrayList(StackEntry).init(self.allocator);
+            defer stack.deinit();
+
+            try stack.append(.{ .node = input_node, .plain = plain, .phase = .Pre });
+
+            while (stack.popOrNull()) |entry| {
+                switch (entry.phase) {
+                    .Pre => {
+                        var new_plain: bool = undefined;
+                        if (entry.plain) {
+                            switch (entry.node.data.value) {
+                                .Text, .HtmlInline, .Code => |literal| {
+                                    try self.writeAll(literal);
+                                },
+                                .LineBreak, .SoftBreak => {
+                                    try self.writeAll(" ");
+                                },
+                                else => {},
+                            }
+                            new_plain = entry.plain;
+                        } else {
+                            try stack.append(.{ .node = entry.node, .plain = false, .phase = .Post });
+                            new_plain = try self.fnode(entry.node, true);
+                        }
+
+                        var it = entry.node.reverseChildrenIterator();
+                        while (it.next()) |ch| {
+                            try stack.append(.{ .node = ch, .plain = new_plain, .phase = .Pre });
+                        }
+                    },
+                    .Post => {
+                        std.debug.assert(!entry.plain);
+                        _ = try self.fnode(entry.node, false);
+                    },
+                }
+            }
+        }
+
+        fn fnode(self: *Self, node: *AstNode, entering: bool) !bool {
+            switch (node.data.value) {
+                .Document => {},
+                .BlockQuote => {
+                    if (entering) {
+                        try self.writeAll("\n");
+                    } else {
+                        try self.cr();
+                    }
+                },
+                .List => |_| {
+                    if (entering) {
+                        try self.cr();
+                    } else {
+                        try self.writeAll("\n");
+                    }
+                },
+                .Item => |parent| {
+                    if (entering) {
+                        try self.cr();
+                        if (parent.list_type == .Bullet) {
+                            try self.writeAll("• ");
+                        } else {
+                            try self.writer.print("{d}. ", .{parent.start});
+                        }
+                    } else {
+                        try self.cr();
+                    }
+                },
+                .Heading => |nch| {
+                    if (entering) {
+                        try self.cr();
+                        for (0..(nch.level + 1)) |_| {
+                            try self.writeAll("#");
+                        }
+                        try self.writeAll(" ");
+                    } else {
+                        try self.writeAll("\n");
+                    }
+                },
+                .CodeBlock => |ncb| {
+                    if (entering) {
+                        try self.cr();
+                        const got_language = if (ncb.info) |info| codeTag: {
+                            if (info.len == 0) break :codeTag false;
+
+                            var first_tag: usize = 0;
+                            while (first_tag < ncb.info.?.len and !ascii.isWhitespace(ncb.info.?[first_tag])) {
+                                first_tag += 1;
+                            }
+
+                            try self.writer.print(ansi.WHITE ++ "```{s}" ++ ansi.DEFAULT, .{info[0..first_tag]});
+                            try self.writeAll("\n");
+
+                            break :codeTag true;
+                        } else false;
+
+                        if (!got_language) {
+                            try self.writeAll("```\n");
+                        }
+
+                        try self.writeAll(ansi.YELLOW);
+                        try self.writeAll(ncb.literal.items);
+                        try self.writeAll(ansi.DEFAULT);
+
+                        try self.writeAll(ansi.WHITE ++ "```\n\n" ++ ansi.DEFAULT);
+                    }
+                },
+                .HtmlBlock => |_| {
+                    if (entering) {
+                        try self.cr();
+                        try self.writeAll("<!-- raw HTML omitted -->");
+                        try self.cr();
+                    }
+                },
+                .ThematicBreak => {
+                    if (entering) {
+                        try self.cr();
+                        try self.writeAll("____________________________________________________\n");
+                    }
+                },
+                .Paragraph => {
+                    const tight = node.parent != null and node.parent.?.parent != null and switch (node.parent.?.parent.?.data.value) {
+                        .List => |nl| nl.tight,
+                        else => false,
+                    };
+
+                    if (!tight and !entering) {
+                        try self.writeAll("\n\n");
+                    }
+                },
+                .Text => |literal| {
+                    const skip = blk: {
+                        if (node.parent) |prev| {
+                            const active_tag = std.meta.activeTag(prev.data.value);
+                            if (active_tag == .Link or active_tag == .Image) {
+                                break :blk true;
+                            }
+                        }
+                        break :blk false;
+                    };
+
+                    if (entering and !skip) {
+                        try self.writeAll(literal);
+                    }
+                },
+                .LineBreak, .SoftBreak => {
+                    if (entering) {
+                        try self.writeAll("\n");
+                    }
+                },
+                .Code => |literal| {
+                    if (entering) {
+                        try self.writeAll(ansi.YELLOW);
+                        try self.writeAll(literal);
+                        try self.writeAll(ansi.DEFAULT);
+                    }
+                },
+                .HtmlInline => |_| {
+                    if (entering) {
+                        try self.writeAll("<!-- raw HTML omitted -->");
+                    }
+                },
+                .Strong => {
+                    try self.writeAll(if (entering) ansi.BOLD else ansi.R_BOLD);
+                },
+                .Emph => {
+                    try self.writeAll(if (entering) ansi.ITALIC else ansi.R_ITALIC);
+                },
+                .Strikethrough => {
+                    try self.writeAll(if (entering) ansi.STRIKE else ansi.R_STRIKE);
+                },
+                .Link => |nl| {
+                    // This is quite an ugly hack for getting the real title.
+                    // The title node shows up inside the link node, so we just
+                    // take the first child and run with it if it's of type `Text`.
+                    // This probably won't work with marked-up titles, so this
+                    // will handle that semi-gracefully to avoid panics.
+                    //
+                    // This is likely a parsing issue as the title field should be empty.
+                    const title = blk: {
+                        if (node.first_child) |child| {
+                            if (std.meta.activeTag(child.data.value) == .Text) {
+                                break :blk child.data.value.Text;
+                            }
+                        }
+                        break :blk "";
+                    };
+
+                    if (entering) {
+                        try self.writer.print(ansi.GREEN ++ "{s} " ++ ansi.BLUE ++ ansi.UNDERLINE ++ "{s}" ++ ansi.DEFAULT ++ ansi.R_UNDERLINE, .{ title, nl.url });
+                    }
+                },
+                .Image => |nl| {
+                    // This is quite an ugly hack for getting the real title.
+                    // The title node shows up inside the image node, so we just
+                    // take the first child and run with it if it's of type `Text`.
+                    // This probably won't work with marked-up titles, so this
+                    // will handle that semi-gracefully to avoid panics.
+                    //
+                    // This is likely a parsing issue as the title field should not be empty.
+                    const title = blk: {
+                        if (node.first_child) |child| {
+                            if (std.meta.activeTag(child.data.value) == .Text) {
+                                break :blk child.data.value.Text;
+                            }
+                        }
+                        break :blk "";
+                    };
+
+                    if (entering) {
+                        try self.writer.print(ansi.GREEN ++ "!{s}" ++ ansi.BLUE ++ " {s} " ++ ansi.DEFAULT, .{ title, nl.url });
+                    }
+                },
+                // Tables are quite uncommon, so they should just be printed verbatim.
+                // Don't try to format these, as they take too much effort to decode
+                // and will likely obscure the meaning conveyed.
+                .Table => {
+                    if (entering) {
+                        try self.cr();
+                        try self.writeAll(node.data.content.items);
+                    }
+                },
+                .TableRow, .TableCell => {},
+            }
+            return false;
+        }
+    };
+}

--- a/src/utils/markdown.zig
+++ b/src/utils/markdown.zig
@@ -263,7 +263,13 @@ pub fn ANSIFormatter(comptime Writer: type) type {
                     };
 
                     if (entering) {
-                        try self.writer.print(ansi.GREEN ++ "{s} " ++ ansi.BLUE ++ ansi.UNDERLINE ++ "{s}" ++ ansi.DEFAULT ++ ansi.R_UNDERLINE, .{ title, nl.url });
+                        // Beacuse of the above-mentioned hack, sometimes the link and the text node
+                        // will have the same content. Just omit the title content in this case.
+                        if (mem.eql(u8, title, nl.url)) {
+                            try self.writer.print(ansi.BLUE ++ ansi.UNDERLINE ++ "{s}" ++ ansi.DEFAULT ++ ansi.R_UNDERLINE, .{nl.url});
+                        } else {
+                            try self.writer.print(ansi.GREEN ++ "{s} " ++ ansi.BLUE ++ ansi.UNDERLINE ++ "{s}" ++ ansi.DEFAULT ++ ansi.R_UNDERLINE, .{ title, nl.url });
+                        }
                     }
                 },
                 .Image => |nl| {

--- a/src/utils/vaxis.zig
+++ b/src/utils/vaxis.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const fmt = std.fmt;
 const mem = std.mem;
 const Allocator = mem.Allocator;
 
@@ -28,9 +29,74 @@ pub fn appendToTextBuffer(allocator: Allocator, vx: vaxis.Vaxis, buf: *TextViewB
 
 /// Append content to a TextView.Buffer, parsing out the ANSI codes
 /// into applicable libvaxis styles.
+///
+/// This only works with the defined codes in utils/ansi.zig.
 pub fn appendToTextBufferANSI(allocator: Allocator, vx: vaxis.Vaxis, buf: *TextViewBuffer, content: []const u8) !void {
-    _ = allocator;
-    _ = vx;
-    _ = buf;
-    _ = content;
+    // This is the style to apply to the current slice.
+    // This will get updated upon every ANSI style encountered.
+    var style: vaxis.Style = .{};
+
+    var input = content;
+    while (true) {
+        const esc_start = mem.indexOf(u8, input, "\x1B[") orelse {
+            // No more escape sequences exist, just write the
+            // rest of the string and return
+            try appendToTextBuffer(allocator, vx, buf, input, style);
+            break;
+        };
+
+        const esc_end = mem.indexOf(u8, input[esc_start..], "m") orelse return error.MissingTerminator;
+
+        const sequence = input[esc_start .. esc_start + esc_end + 1];
+        const text_before_esc = input[0..esc_start];
+
+        try appendToTextBuffer(allocator, vx, buf, text_before_esc, style);
+        updateVaxisStyleANSI(&style, sequence);
+
+        input = input[esc_start + esc_end + 1 ..];
+    }
+}
+
+/// Parse an ANSI sequence and update the corresponding Vaxis sstyle.
+///
+/// Only works with the codes defined in utils/ansi.zig; other codes are ignored.
+/// Also, this is terrible code. This needs to be updated to parse ANSI styles
+/// generically and apply them as such.
+fn updateVaxisStyleANSI(style: *vaxis.Style, code: []const u8) void {
+    const bytes = code[2 .. code.len - 1];
+
+    // Ignore ANSI escape codes that are not numbers.
+    const num = fmt.parseInt(usize, bytes, 10) catch return;
+
+    switch (num) {
+        // Reset everything
+        0 => style.* = .{},
+
+        // Text styles
+        1 => style.*.bold = true,
+        2 => style.*.dim = true,
+        3 => style.*.italic = true,
+        4 => style.*.ul_style = .single,
+        9 => style.*.strikethrough = true,
+
+        // Text style resets
+        21 => style.*.bold = false,
+        22 => style.*.dim = false,
+        23 => style.*.italic = false,
+        24 => style.*.ul_style = .off,
+        29 => style.*.strikethrough = false,
+
+        // Foreground colors
+        30 => style.*.fg = .{ .index = 0 },
+        31 => style.*.fg = .{ .index = 1 },
+        32 => style.*.fg = .{ .index = 2 },
+        33 => style.*.fg = .{ .index = 3 },
+        34 => style.*.fg = .{ .index = 4 },
+        35 => style.*.fg = .{ .index = 5 },
+        36 => style.*.fg = .{ .index = 6 },
+        37 => style.*.fg = .{ .index = 7 },
+        39 => style.*.fg = .default,
+
+        else => {},
+    }
 }

--- a/src/utils/vaxis.zig
+++ b/src/utils/vaxis.zig
@@ -1,0 +1,36 @@
+const std = @import("std");
+const mem = std.mem;
+const Allocator = mem.Allocator;
+
+const vaxis = @import("vaxis");
+const TextInput = vaxis.widgets.TextInput;
+const TextView = vaxis.widgets.TextView;
+const TextViewBuffer = TextView.Buffer;
+
+/// Append content to a TextView.Buffer with the given style
+/// applied to the passed contents.
+pub fn appendToTextBuffer(allocator: Allocator, vx: vaxis.Vaxis, buf: *TextViewBuffer, content: []const u8, style: vaxis.Style) !void {
+    const begin = buf.content.items.len;
+    const end = begin + content.len + 1;
+
+    try buf.append(allocator, .{
+        .bytes = content,
+        .gd = &vx.unicode.grapheme_data,
+        .wd = &vx.unicode.width_data,
+    });
+
+    try buf.updateStyle(allocator, .{
+        .begin = begin,
+        .end = end,
+        .style = style,
+    });
+}
+
+/// Append content to a TextView.Buffer, parsing out the ANSI codes
+/// into applicable libvaxis styles.
+pub fn appendToTextBufferANSI(allocator: Allocator, vx: vaxis.Vaxis, buf: *TextViewBuffer, content: []const u8) !void {
+    _ = allocator;
+    _ = vx;
+    _ = buf;
+    _ = content;
+}


### PR DESCRIPTION
I've been wanting to do this for a while.

Most option descriptions have extra markup related to `nixpkgs`, and are written in Markdown.
I wanted to parse this markdown and render it myself using ANSI codes. That's what this PR brings in; it parses markdown using https://github.com/kivikakk/koino, and adds ANSI codes to the descriptions.

The code is crude, but it gets the job done. I'll address how to do this properly (such as adding proper indentations, fixing bugs) later. It can be disabled in the config using `option.prettify=false`  if it does mess up with rendering some options.

This is an example of the new description rendering.
![2024-08-26_16-32-57](https://github.com/user-attachments/assets/1ec59a13-0d09-4142-b493-167fe1aa7f67)

Closes #26.