### PR TITLE
feat(apply): add setting to use git commit message as description

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -25,6 +25,10 @@ use_nom = false
 # This only applies for flake configurations, and is always true in the
 # case of legacy configurations.
 imply_impure_with_tag = false
+# Use the Git commit message as the description tag for the
+# generation automatically if a tag is not provided.
+# This setting does not work with dirty Git trees.
+use_git_commit_msg = false
 
 # Configuration for the `enter` subcommand.
 [enter]

--- a/src/config.zig
+++ b/src/config.zig
@@ -75,6 +75,7 @@ pub const Config = struct {
         imply_impure_with_tag: bool = false,
         specialisation: ?[]const u8 = null,
         use_nom: bool = false,
+        use_git_commit_msg: bool = false,
     } = .{},
     config_location: []const u8 = "/etc/nixos",
     enter: struct {

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -253,7 +253,7 @@ fn repl(allocator: Allocator, args: ReplCommand) ReplError!void {
 
         execFlakeRepl(allocator, flake_ref, args.includes.items) catch return ReplError.ReplExecError;
     } else {
-        utils.verifyLegacyConfigurationExists(allocator, false) catch return ReplError.ConfigurationNotFound;
+        _ = utils.findLegacyConfiguration(false) catch return ReplError.ConfigurationNotFound;
         execLegacyRepl(allocator, args.includes.items, posix.getenv("NIXOS_CONFIG") != null) catch return ReplError.ReplExecError;
     }
 }


### PR DESCRIPTION
Many people use `git` to manage their NixOS configurations. The commits that they make (unless they're bad at making commit messages) usually can serve as a good indicator of what has changed for that system, and is more often than not followed by applying the configuration after finishing the commit.

This adds a setting to automatically check the configuration directory upon application and see if it is a `git` repo, and if it is, it will retrieve the most recent commit message and use that as the generation description. This won't work on dirty trees, to mimic the behavior of Nix.