### PR TITLE
refactor: simplify color formatting

### DIFF
--- a/src/apply.zig
+++ b/src/apply.zig
@@ -173,6 +173,10 @@ pub const ApplyCommand = struct {
                 const next_args = try getNextArgs(args, arg, 2);
                 try parsed.build_options.appendSlice(&.{ arg, next_args[0], next_args[1] });
             } else {
+                if (argparse.isFlag(arg)) {
+                    return arg;
+                }
+
                 if (opts.flake and parsed.flake == null) {
                     parsed.flake = arg;
                 } else {

--- a/src/config.zig
+++ b/src/config.zig
@@ -206,11 +206,7 @@ pub fn deinit() void {
 }
 
 fn configError(comptime fmt: []const u8, args: anytype) void {
-    if (Constants.use_color) {
-        log.print(ansi.BOLD ++ ansi.RED ++ "error" ++ ansi.RESET ++ ": ", .{});
-    } else {
-        log.print("error: ", .{});
-    }
+    log.print(ansi.BOLD ++ ansi.RED ++ "error" ++ ansi.RESET ++ ": ", .{});
     log.print("invalid setting: ", .{});
     log.print(fmt ++ "\n", args);
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -77,6 +77,7 @@ pub const Config = struct {
         use_nom: bool = false,
         use_git_commit_msg: bool = false,
     } = .{},
+    color: bool = true,
     config_location: []const u8 = "/etc/nixos",
     enter: struct {
         mount_resolv_conf: bool = true,

--- a/src/generation/list.zig
+++ b/src/generation/list.zig
@@ -92,7 +92,7 @@ fn listGenerations(allocator: Allocator, profile_name: []const u8, args: Generat
     }
 
     for (generations, 0..) |gen, i| {
-        gen.prettyPrint(.{ .color = Constants.use_color }, stdout) catch unreachable;
+        gen.prettyPrint(.{}, stdout) catch unreachable;
         if (i != generations.len - 1) {
             print(stdout, "\n", .{});
         }

--- a/src/info.zig
+++ b/src/info.zig
@@ -159,7 +159,6 @@ fn info(allocator: Allocator, args: InfoCommand) InfoError!void {
     }
 
     generation_info.prettyPrint(.{
-        .color = Constants.use_color,
         .show_current_marker = false,
     }, stdout) catch unreachable;
 }

--- a/src/option.zig
+++ b/src/option.zig
@@ -286,10 +286,7 @@ fn displayOption(allocator: Allocator, opt: NixosOption, evaluated: EvaluatedVal
             break :blk mem.trim(u8, rendered, "\n ");
         }
 
-        break :blk if (Constants.use_color)
-            ansi.ITALIC ++ "(none)" ++ ansi.RESET
-        else
-            "(none)";
+        break :blk ansi.ITALIC ++ "(none)" ++ ansi.RESET;
     };
     defer if (desc_alloc) allocator.free(description);
 
@@ -301,60 +298,35 @@ fn displayOption(allocator: Allocator, opt: NixosOption, evaluated: EvaluatedVal
     };
     const example = if (opt.example) |e| mem.trim(u8, e.text, "\n ") else null;
 
-    if (Constants.use_color) {
-        println(stdout, ansi.BOLD ++ "Name\n" ++ ansi.RESET ++ "{s}\n", .{opt.name});
-        println(stdout, ansi.BOLD ++ "Description\n" ++ ansi.RESET ++ "{s}\n", .{description});
-        println(stdout, ansi.BOLD ++ "Type\n" ++ ansi.RESET ++ ansi.ITALIC ++ "{s}\n" ++ ansi.RESET, .{opt.type});
-        println(stdout, ansi.BOLD ++ "Value" ++ ansi.RESET, .{});
-        if (std.meta.activeTag(evaluated) == .success) {
-            println(stdout, "{s}\n", .{evaluated.success});
-        } else {
-            println(stdout, ansi.RED ++ "error: {s}\n" ++ ansi.RESET, .{evaluated.@"error"});
-        }
-
-        println(stdout, ansi.BOLD ++ "Default" ++ ansi.RESET, .{});
-        if (opt.default) |_| {
-            println(stdout, ansi.WHITE ++ "{s}" ++ ansi.RESET, .{default});
-        } else {
-            println(stdout, ansi.ITALIC ++ "(none)" ++ ansi.RESET, .{});
-        }
-        println(stdout, "", .{});
-
-        if (example) |e| {
-            println(stdout, ansi.BOLD ++ "Example\n" ++ ansi.RESET ++ "{s}\n", .{e});
-        }
-        if (opt.declarations.len > 0) {
-            println(stdout, ansi.BOLD ++ "Declared In" ++ ansi.RESET, .{});
-            for (opt.declarations) |decl| {
-                println(stdout, ansi.ITALIC ++ "  - {s}" ++ ansi.RESET, .{decl});
-            }
-        }
-        if (opt.readOnly) {
-            println(stdout, ansi.YELLOW ++ "\nThis option is read-only." ++ ansi.RESET, .{});
-        }
+    println(stdout, ansi.BOLD ++ "Name\n" ++ ansi.RESET ++ "{s}\n", .{opt.name});
+    println(stdout, ansi.BOLD ++ "Description\n" ++ ansi.RESET ++ "{s}\n", .{description});
+    println(stdout, ansi.BOLD ++ "Type\n" ++ ansi.RESET ++ ansi.ITALIC ++ "{s}\n" ++ ansi.RESET, .{opt.type});
+    println(stdout, ansi.BOLD ++ "Value" ++ ansi.RESET, .{});
+    if (std.meta.activeTag(evaluated) == .success) {
+        println(stdout, "{s}\n", .{evaluated.success});
     } else {
-        println(stdout, "Name\n{s}\n", .{opt.name});
-        println(stdout, "Description\n{s}\n", .{description});
-        println(stdout, "Type\n{s}\n", .{opt.type});
-        println(stdout, "Value", .{});
-        if (std.meta.activeTag(evaluated) == .success) {
-            println(stdout, "{s}\n", .{evaluated.success});
-        } else {
-            println(stdout, "error: {s}\n", .{evaluated.@"error"});
+        println(stdout, ansi.RED ++ "error: {s}\n" ++ ansi.RESET, .{evaluated.@"error"});
+    }
+
+    println(stdout, ansi.BOLD ++ "Default" ++ ansi.RESET, .{});
+    if (opt.default) |_| {
+        println(stdout, ansi.WHITE ++ "{s}" ++ ansi.RESET, .{default});
+    } else {
+        println(stdout, ansi.ITALIC ++ "(none)" ++ ansi.RESET, .{});
+    }
+    println(stdout, "", .{});
+
+    if (example) |e| {
+        println(stdout, ansi.BOLD ++ "Example\n" ++ ansi.RESET ++ "{s}\n", .{e});
+    }
+    if (opt.declarations.len > 0) {
+        println(stdout, ansi.BOLD ++ "Declared In" ++ ansi.RESET, .{});
+        for (opt.declarations) |decl| {
+            println(stdout, ansi.ITALIC ++ "  - {s}" ++ ansi.RESET, .{decl});
         }
-        println(stdout, "Default\n{s}\n", .{default});
-        if (example) |e| {
-            println(stdout, "Example\n{s}\n", .{e});
-        }
-        if (opt.declarations.len > 0) {
-            println(stdout, "Declared In", .{});
-            for (opt.declarations) |decl| {
-                println(stdout, "  - {s}", .{decl});
-            }
-        }
-        if (opt.readOnly) {
-            println(stdout, "\nThis option is read-only.", .{});
-        }
+    }
+    if (opt.readOnly) {
+        println(stdout, ansi.YELLOW ++ "\nThis option is read-only." ++ ansi.RESET, .{});
     }
 }
 

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -19,8 +19,6 @@ const argError = argparse.argError;
 const argIs = argparse.argIs;
 const getNextArgs = argparse.getNextArgs;
 
-const Constants = @import("constants.zig");
-
 const log = @import("log.zig");
 
 const utils = @import("utils.zig");
@@ -133,7 +131,7 @@ const flake_motd_template =
 
 fn execFlakeRepl(allocator: Allocator, ref: FlakeRef, includes: []const []const u8) !void {
     // zig fmt: off
-    const motd = if (Constants.use_color) try fmt.allocPrint(allocator, flake_motd_template, .{
+    const motd = try fmt.allocPrint(allocator, flake_motd_template, .{
         ansi.CYAN,    ref.uri,    ref.system,   ansi.RESET,
         ansi.MAGENTA, ansi.RESET,
         ansi.MAGENTA, ansi.RESET,
@@ -143,16 +141,6 @@ fn execFlakeRepl(allocator: Allocator, ref: FlakeRef, includes: []const []const 
         ansi.GREEN,   ansi.RESET,
         ansi.GREEN,   ansi.RESET,
         ansi.YELLOW,  ansi.RESET, ansi.CYAN, ansi.RESET,
-    }) else try fmt.allocPrint(allocator, flake_motd_template, .{
-        "", ref.uri, ref.system, "",
-        "",      "",
-        "",      "",
-        "",      "",
-        "",      "",         "", "",
-        "",      "",         "", "",
-        "",      "",
-        "",      "",
-        "",      "",         "", ""
     });
     // zig fmt: on
 
@@ -203,25 +191,13 @@ fn execLegacyRepl(allocator: Allocator, includes: []const []const u8, impure: bo
     defer argv.deinit();
 
     // zig fmt: off
-    const motd = if (Constants.use_color) try fmt.allocPrint(allocator, legacy_motd_template, .{
+    const motd = try fmt.allocPrint(allocator, legacy_motd_template, .{
         ansi.MAGENTA, ansi.RESET,
         ansi.MAGENTA, ansi.RESET,
         ansi.MAGENTA, ansi.RESET, ansi.CYAN,    ansi.RESET,
         ansi.MAGENTA, ansi.RESET, ansi.MAGENTA, ansi.RESET,
         ansi.GREEN,   ansi.RESET,
         ansi.GREEN,   ansi.RESET,
-    }) else try fmt.allocPrint(allocator, flake_motd_template, .{
-        "", "",
-        "", "",
-        "", "", "", "",
-        "", "", "", "",
-        "", "",
-        "", "",
-        "", "",
-        "", "",
-        "", "",
-        "", "",
-        "", "",
     });
     // zig fmt: on
 

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -18,14 +18,22 @@ const config = @import("config.zig");
 const Constants = @import("constants.zig");
 
 const log = @import("./log.zig");
+const ANSIFilter = log.ANSIFilter;
 
 /// Print to a writer, ignoring errors.
 pub fn print(out: anytype, comptime format: []const u8, args: anytype) void {
-    out.print(format, args) catch return;
+    var color_filter = ANSIFilter(@TypeOf(out)){ .raw_writer = out };
+    const writer = color_filter.writer();
+
+    writer.print(format, args) catch return;
 }
+
 /// Print to a writer with a newline, ignoring errors.
 pub fn println(out: anytype, comptime format: []const u8, args: anytype) void {
-    out.print(format ++ "\n", args) catch return;
+    var color_filter = ANSIFilter(@TypeOf(out)){ .raw_writer = out };
+    const writer = color_filter.writer();
+
+    writer.print(format ++ "\n", args) catch return;
 }
 
 /// Result from a command; output of commands meant for

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -18,7 +18,7 @@ const config = @import("config.zig");
 const Constants = @import("constants.zig");
 
 const log = @import("./log.zig");
-const ANSIFilter = log.ANSIFilter;
+const ANSIFilter = ansi.ANSIFilter;
 
 /// Print to a writer, ignoring errors.
 pub fn print(out: anytype, comptime format: []const u8, args: anytype) void {
@@ -463,11 +463,7 @@ pub fn confirmationInput(prompt: []const u8) !bool {
     var input_buf: [100]u8 = undefined;
     const stdin = io.getStdIn().reader();
 
-    if (Constants.use_color) {
-        log.print(ansi.GREEN ++ "|> {s}?" ++ ansi.RESET ++ "\n[y/n]: ", .{prompt});
-    } else {
-        log.print("|> {s}?\n[y/n]: ", .{prompt});
-    }
+    log.print(ansi.GREEN ++ "|> {s}?" ++ ansi.RESET ++ "\n[y/n]: ", .{prompt});
 
     const input = stdin.readUntilDelimiter(&input_buf, '\n') catch |err| {
         log.err("unable to read stdin for confirmation: {s}", .{@errorName(err)});


### PR DESCRIPTION
This doesn't bring any new features, but rather simplifies color handling.

In order to respect the user's preference for printing colors (i.e. for printing to a file), this adds a configuration setting and
a global flag that forces color even when printing to a file, much like `less` does.

Additionally, this does a huge refactor of how colors are handled. Before, this used to just check the conditional directly and change the format string to have ANSI codes or not have ANSI codes. This is awkward as hell, since you have to do this everywhere and duplicate formatting logic in so many places that this becomes quite unwieldy. This creates an `ANSIFilter` writer that wraps over another writer, and either prints or doesn't print any ANSI codes that it encounters. That way, we only have to check in one place whether or not we should render these colors, provided that the developer is using the provided `log` and `utils.print` utilities.