### PR TITLE
fix(deps): use forked version of libvaxis, update zf

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -21,16 +21,16 @@
             .hash = "1220ced9b2f6943f688ce1e20a40f143d83c4182320e4b9d30e470b010d44b356f0a",
         },
         .zf = .{
-            .url = "https://github.com/natecraddock/zf/archive/91bc9808bebddd5e1663ffde009bf4510a45e48d.tar.gz",
-            .hash = "1220a763e0496d7dade9329044fbac181eaf7c1a1f4f51ab5e3a0a77d986615aa4e4",
+            .url = "https://github.com/natecraddock/zf/archive/ed99ca18b02dda052e20ba467e90b623c04690dd.tar.gz",
+            .hash = "1220edc3b8d8bedbb50555947987e5e8e2f93871ca3c8e8d4cc8f1377c15b5dd35e8",
         },
         .zeit = .{
             .url = "https://github.com/rockorager/zeit/archive/1d2dc95d73160096f84830e54b419514e41e78e8.tar.gz",
             .hash = "1220aad3a3b05b27a2453ddb68caa70a656c530f69e321cf79a89d2a9c4b2dd51640",
         },
         .vaxis = .{
-            .url = "https://github.com/rockorager/libvaxis/archive/d36ab043caf7cbb24cae1bd0346dd6b654df0653.tar.gz",
-            .hash = "12206c252ee00b9dd0214989dfa35a6eea29ac7d65d4053817f161f4c23b6e09dd89",
+            .url = "https://github.com/water-sucks/libvaxis/archive/2dce933ccca04a87bc6ccf690ddf516516cb2acb.tar.gz",
+            .hash = "12208b59a13aa5211bc93dcdc00c05ca171f87a7d1ca3599aeaa83bb3bf1df388eb1",
         },
         .koino = .{
             .url = "https://github.com/kivikakk/koino/archive/0151bb37714d93688f31e3d7a3d0369106818f26.tar.gz",

--- a/package.nix
+++ b/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
       inherit stdenv zig;
       name = pname;
       src = ./.;
-      depsHash = "sha256-TNiG5pxvESsAWCAz4BEwie+CMO6ZoNKdnm3qo6wNc4c=";
+      depsHash = "sha256-HvGYGbvfhgdVY9i6HrEMyhtLlWb8xo6G3zvoUz7LMas=";
     };
   in ''
     mkdir -p .cache

--- a/src/utils/search.zig
+++ b/src/utils/search.zig
@@ -31,7 +31,7 @@ pub fn rankCandidates(
 
     var index: usize = 0;
     for (candidates) |candidate| {
-        if (zf.rank(candidate, tokens, case_sensitive, plain)) |rank| {
+        if (zf.rank(candidate, tokens, .{ .plain = plain, .to_lower = !case_sensitive })) |rank| {
             ranked[index] = .{ .str = candidate, .rank = rank };
             index += 1;
         }
@@ -79,7 +79,7 @@ pub fn rankCandidatesStruct(
             }
         };
 
-        if (zf.rank(candidate_str, tokens, case_sensitive, plain)) |rank| {
+        if (zf.rank(candidate_str, tokens, .{ .plain = plain, .to_lower = !case_sensitive })) |rank| {
             ranked[index] = .{ .value = candidate, .rank = rank };
             index += 1;
         }

--- a/src/utils/vaxis.zig
+++ b/src/utils/vaxis.zig
@@ -16,7 +16,7 @@ pub fn appendToTextBuffer(allocator: Allocator, vx: vaxis.Vaxis, buf: *TextViewB
 
     try buf.append(allocator, .{
         .bytes = content,
-        .gd = &vx.unicode.grapheme_data,
+        .gd = &vx.unicode.width_data.g_data,
         .wd = &vx.unicode.width_data,
     });
 


### PR DESCRIPTION
Fun fact, EVERYTHING in the world broke after someone renamed their codeberg repository.

I'm just kidding, but someone did rename their codeberg repo and it caused some breakage. I just realized that patching dependencies is extremely hard with `zig-deps-fod`, so I just went through and manually updated all the packages that contained the zg dependency that was renamed.

And since I haven't updated libvaxis in a while, this caused some fun breakage there as well, since everything in the world uses u16 now (except NO, everything in the world does NOT use u16 and I ended up FORKING this damn repo JUST to truncate some extra widgets that weren't apparently touched).

Welp, that's it. I was already thinking about porting this to Go for months, and this only solidifies that decision. As much as I love Zig, this doesn't appear to be the right fit for this tool.