### PR TITLE
fix(option): add flake ref argument to option command

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -178,6 +178,10 @@ func applyMain(cmd *cobra.Command, opts *cmdTypes.ApplyOpts) error {
 	var nixConfig configuration.Configuration
 	if opts.FlakeRef != "" {
 		nixConfig = configuration.FlakeRefFromString(opts.FlakeRef)
+		if err := nixConfig.(*configuration.FlakeRef).InferSystemFromHostnameIfNeeded(); err != nil {
+			log.Errorf("failed to infer hostname: %v", err)
+			return err
+		}
 	} else {
 		c, err := configuration.FindConfiguration(log, cfg, opts.NixOptions.Includes, opts.Verbose)
 		if err != nil {

--- a/cmd/option/option.go
+++ b/cmd/option/option.go
@@ -299,10 +299,11 @@ func prettyPrintOption(o *option.NixosOption, evaluatedValue *string, evalTrace 
 
 	valueText := ""
 	if evaluatedValue == nil {
-		valueText = color.RedString("failed to evaluate value: %v")
+		valueText = "failed to evaluate value"
 		if evalTrace != "" {
-			valueText = fmt.Sprintf("%v: %v", valueText, evalTrace)
+			valueText += fmt.Sprintf(" %v: %v", valueText, evalTrace)
 		}
+		valueText = color.RedString(valueText)
 	} else {
 		valueText = color.WhiteString(strings.TrimSpace(*evaluatedValue))
 	}

--- a/cmd/option/option.go
+++ b/cmd/option/option.go
@@ -96,6 +96,10 @@ func optionMain(cmd *cobra.Command, opts *cmdTypes.OptionOpts) error {
 	var nixosConfig configuration.Configuration
 	if opts.FlakeRef != "" {
 		nixosConfig = configuration.FlakeRefFromString(opts.FlakeRef)
+		if err := nixosConfig.(*configuration.FlakeRef).InferSystemFromHostnameIfNeeded(); err != nil {
+			log.Errorf("failed to infer hostname: %v", err)
+			return err
+		}
 	} else {
 		c, err := configuration.FindConfiguration(log, cfg, opts.NixPathIncludes, false)
 		if err != nil {

--- a/cmd/repl/repl.go
+++ b/cmd/repl/repl.go
@@ -21,8 +21,13 @@ import (
 func ReplCommand() *cobra.Command {
 	opts := cmdTypes.ReplOpts{}
 
+	usage := "repl [flags]"
+	if buildOpts.Flake == "true" {
+		usage += " [FLAKE-REF]"
+	}
+
 	cmd := cobra.Command{
-		Use:   "repl [flags] [FLAKE-REF]",
+		Use:   usage,
 		Short: "Start a Nix REPL with system configuration loaded",
 		Long:  "Start a Nix REPL with current system's configuration loaded.",
 		Args: func(cmd *cobra.Command, args []string) error {
@@ -46,10 +51,12 @@ func ReplCommand() *cobra.Command {
 
 	nixopts.AddIncludesNixOption(&cmd, &opts.NixPathIncludes)
 
-	cmd.SetHelpTemplate(cmd.HelpTemplate() + `
+	if buildOpts.Flake == "true" {
+		cmd.SetHelpTemplate(cmd.HelpTemplate() + `
 Arguments:
     [FLAKE-REF]  Flake ref to load attributes from (default: $NIXOS_CONFIG)
 `)
+	}
 
 	return &cmd
 }

--- a/doc/man/nixos-cli-apply.1.scd
+++ b/doc/man/nixos-cli-apply.1.scd
@@ -64,15 +64,12 @@ command tree. See *nixos-cli-generation(1)* for details.
 # ARGUMENTS
 
 *FLAKE-REF*
-	If running on a flake-enabled CLI, *FLAKE-REF* can be provided in the form
-	of *<FLAKE-URI>#<SYSTEM>* in order to build configurations not on the local
-	machine that can be referenced with flake ref syntax.
+	Specify an explicit flake ref with a NixOS configuration. Only available
+	on flake-enabled CLIs.
 
-	Internally, a flake ref gets expanded to the Nix flake attribute
-	_FLAKE-URI#nixosConfigurations.SYSTEM_ whenever necessary.
+	See *nixos-config-env(5)* for the proper flake ref format.
 
-	If not provided, then this argument will be auto-populated with the
-	*$NIXOS_CONFIG* environment variable, which must be a valid flake ref.
+	Default: *$NIXOS_CONFIG*
 
 # OPTIONS
 

--- a/doc/man/nixos-cli-env.5.scd
+++ b/doc/man/nixos-cli-env.5.scd
@@ -36,13 +36,26 @@ Among other things.
 
 	*Flake-enabled CLIs:*
 		This must be a valid flake ref (e.g., */home/user/config* or
-		*github:myorg/nixos-config*).
+		*github:myorg/nixos-config#attr*).
 
 		Flake refs without a local path may have slightly different behavior,
 		such as not supporting implicit Git operations. Check relevant man pages
 		for more information.
 
-		Paths _MUST_ be absolute. Use *realpath(1)* if you must.
+		If a flake ref is a path, it _MUST_ be absolute. Use *realpath(1)* if
+		you must.
+
+		Additionally, flake refs will usually be expanded when necessary.
+		For example, the following flake ref:
+
+			_github:water-sucks/nixed#CharlesWoodson_
+
+		will get expanded to the following flake ref and attribute:
+
+			_github:water-sucks/nixed#nixosConfigurations.CharlesWoodson_
+
+		If the ref does not have text after the "#", then the NixOS system
+		attribute name will be inferred to be the current system's hostname.
 
 	*Legacy CLIs:*
 		This can be a path to a configuration file directly

--- a/doc/man/nixos-cli-install.1.scd
+++ b/doc/man/nixos-cli-install.1.scd
@@ -90,15 +90,16 @@ is also possible, assuming a successful installation.
 # ARGUMENTS
 
 *FLAKE-REF*
-	If running on a flake-enabled CLI, *FLAKE-REF* _must_ be provided in the
-	form of *<FLAKE-URI>#<SYSTEM>* in order to build configurations not on the
-	target machine that can be referenced with flake ref syntax.
+	Specify an explicit flake ref to evaluate options from. Only available
+	on flake-enabled CLIs.
+
+	See *nixos-config-env(5)* for the proper flake ref format.
+
+	The system name is NOT inferred from the hostname, and must be provided
+	explicitly after the #.
 
 	There is no fallback, so if this argument is not provided on a flake-enabled
 	CLI, the program will fail.
-
-	Internally, a flake ref gets expanded to the Nix flake attribute
-	_FLAKE-URI#nixosConfigurations.SYSTEM_ whenever necessary.
 
 # OPTIONS
 

--- a/doc/man/nixos-cli-option.1.scd
+++ b/doc/man/nixos-cli-option.1.scd
@@ -47,13 +47,18 @@ Find an option in a different flake ref (assume a flake-enabled CLI):
 	Show the help message for this command.
 
 *-f*, *--flake* <REF>
-	Specify an explicit flake *REF* to evaluate options from.
+	Specify an explicit flake *REF* to evaluate options from. Only available
+	on flake-enabled CLIs.
 
 	If the cache is used to retrieve available options, some options that show
 	up may actually not be available on the target configuration.
 
 	Use the *--no-cache* flag to fully evaluate the option set for this
 	configuration to avoid this issue.
+
+	See *nixos-config-env(5)* for the proper flake ref format.
+
+	Default: *$NIXOS_CONFIG*
 
 *-i*, *--interactive*
 	Start an interactive TUI for exploring options with a search bar.

--- a/doc/man/nixos-cli-option.1.scd
+++ b/doc/man/nixos-cli-option.1.scd
@@ -35,12 +35,25 @@ Find an option and obtain the type using structured JSON output and _jq_:
 
 Find an option using the UI (starting with an initial search):
 
-	*nixos option -i search.for.option.with.this.name*
+	*nixos option -i "search.for.option.with.this.name"*
+
+Find an option in a different flake ref (assume a flake-enabled CLI):
+
+	*nixos option -f "github:MattRStoffel/mixed#nixos-machine" "option.name"*
 
 # OPTIONS
 
 *-h*, *--help*
 	Show the help message for this command.
+
+*-f*, *--flake* <REF>
+	Specify an explicit flake *REF* to evaluate options from.
+
+	If the cache is used to retrieve available options, some options that show
+	up may actually not be available on the target configuration.
+
+	Use the *--no-cache* flag to fully evaluate the option set for this
+	configuration to avoid this issue.
 
 *-i*, *--interactive*
 	Start an interactive TUI for exploring options with a search bar.

--- a/internal/cmd/types/types.go
+++ b/internal/cmd/types/types.go
@@ -180,6 +180,7 @@ type OptionOpts struct {
 	DisplayValueOnly bool
 	MinScore         int64
 	OptionInput      string
+	FlakeRef         string
 }
 
 type ReplOpts struct {


### PR DESCRIPTION
The `nixos option` command does not take an explicit flake ref, and solely relies on environment variables.

This adds the `--flake`/`-f` flag to `nixos option`, as well as fixing up some inconsistencies in behavior when referring to flake refs and formatting.

Closes the issue mentioned in #56.