### PR TITLE
chore: update cobra -> 1.9.1, use its inbuilt CompletionFunc type

### DIFF
--- a/cmd/generation/rollback/rollback.go
+++ b/cmd/generation/rollback/rollback.go
@@ -195,7 +195,7 @@ func findPreviousGeneration(log *logger.Logger, profileName string) (*generation
 	return &generations[currentGenIdx-1], nil
 }
 
-func completeSpecialisationFlag(profileName string) cmdOpts.CompletionFunc {
+func completeSpecialisationFlag(profileName string) cobra.CompletionFunc {
 	profileDirectory := constants.NixProfileDirectory
 	if profileName != "system" {
 		profileDirectory = constants.NixSystemProfileDirectory

--- a/cmd/generation/switch/switch.go
+++ b/cmd/generation/switch/switch.go
@@ -63,7 +63,7 @@ Arguments:
 	return &cmd
 }
 
-func completeSpecialisationFlag(profileName string) cmdOpts.CompletionFunc {
+func completeSpecialisationFlag(profileName string) cobra.CompletionFunc {
 	profileDirectory := constants.NixProfileDirectory
 	if profileName != "system" {
 		profileDirectory = constants.NixSystemProfileDirectory

--- a/cmd/option/completion.go
+++ b/cmd/option/completion.go
@@ -50,7 +50,7 @@ func loadOptions(log *logger.Logger, cfg *settings.Settings, includes []string) 
 	return options, nil
 }
 
-func OptionsCompletionFunc(opts *cmdOpts.OptionOpts) cmdOpts.CompletionFunc {
+func OptionsCompletionFunc(opts *cmdOpts.OptionOpts) cobra.CompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		log := logger.FromContext(cmd.Context())
 		cfg := settings.FromContext(cmd.Context())

--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,8 @@ require (
 	github.com/knadh/koanf/v2 v2.1.2
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/sahilm/fuzzy v0.1.1
-	github.com/spf13/cobra v1.8.1
-	github.com/spf13/pflag v1.0.5
+	github.com/spf13/cobra v1.9.1
+	github.com/spf13/pflag v1.0.6
 	github.com/yarlson/pin v0.9.1
 	golang.org/x/term v0.28.0
 )

--- a/go.sum
+++ b/go.sum
@@ -43,7 +43,7 @@ github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQ
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/cloudflare/circl v1.5.0 h1:hxIWksrX6XN5a1L2TI/h53AGPhNHoUBo+TD1ms9+pys=
 github.com/cloudflare/circl v1.5.0/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
-github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyphar/filepath-securejoin v0.4.0 h1:PioTG9TBRSApBpYGnDU8HC+miIsX8vitBH9LGNNMoLQ=
 github.com/cyphar/filepath-securejoin v0.4.0/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -161,10 +161,10 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.0 h1:AM+y0rI04VksttfwjkSTNQorvGqmwATnvnAHpSgc0LY=
 github.com/skeema/knownhosts v1.3.0/go.mod h1:sPINvnADmT/qYH1kfv+ePMmOBTH6Tbl7b5LvTDjFK7M=
-github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
-github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/internal/cmd/opts/completion.go
+++ b/internal/cmd/opts/completion.go
@@ -1,5 +1,0 @@
-package cmdOpts
-
-import "github.com/spf13/cobra"
-
-type CompletionFunc func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)

--- a/internal/generation/completion.go
+++ b/internal/generation/completion.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/nix-community/nixos-cli/internal/cmd/opts"
 	"github.com/nix-community/nixos-cli/internal/constants"
 	"github.com/nix-community/nixos-cli/internal/logger"
 	"github.com/spf13/cobra"
@@ -39,7 +38,7 @@ func CompleteProfileFlag(_ *cobra.Command, args []string, toComplete string) ([]
 	return profiles, cobra.ShellCompDirectiveNoFileComp
 }
 
-func CompleteGenerationNumber(profile *string, limit int) cmdOpts.CompletionFunc {
+func CompleteGenerationNumber(profile *string, limit int) cobra.CompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		log := logger.FromContext(cmd.Context())
 
@@ -79,7 +78,7 @@ func CompleteGenerationNumber(profile *string, limit int) cmdOpts.CompletionFunc
 	}
 }
 
-func CompleteGenerationNumberFlag(profile *string) cmdOpts.CompletionFunc {
+func CompleteGenerationNumberFlag(profile *string) cobra.CompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		log := logger.FromContext(cmd.Context())
 

--- a/internal/generation/specialisations.go
+++ b/internal/generation/specialisations.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/nix-community/nixos-cli/internal/cmd/opts"
 	"github.com/nix-community/nixos-cli/internal/configuration"
 	"github.com/nix-community/nixos-cli/internal/logger"
 	"github.com/nix-community/nixos-cli/internal/settings"
@@ -65,7 +64,7 @@ func CollectSpecialisationsFromConfig(cfg configuration.Configuration) []string 
 	return specialisations
 }
 
-func CompleteSpecialisationFlag(generationDirname string) cmdOpts.CompletionFunc {
+func CompleteSpecialisationFlag(generationDirname string) cobra.CompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		specialisations, err := CollectSpecialisations(generationDirname)
 		if err != nil {
@@ -88,7 +87,7 @@ func CompleteSpecialisationFlag(generationDirname string) cmdOpts.CompletionFunc
 	}
 }
 
-func CompleteSpecialisationFlagFromConfig(flakeRefStr string, includes []string) cmdOpts.CompletionFunc {
+func CompleteSpecialisationFlagFromConfig(flakeRefStr string, includes []string) cobra.CompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		log := logger.FromContext(cmd.Context())
 		cfg := settings.FromContext(cmd.Context())

--- a/package.nix
+++ b/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   version = "0.12.2-dev";
   src = nix-gitignore.gitignoreSource [] ./.;
 
-  vendorHash = "sha256-Jw8dasyyQd4E/96jo6XB0gdiPDX3O96Nm8mn21fVx9g=";
+  vendorHash = "sha256-e8uwSCkB2MDjsmESqETUc70tDyGWnumvz4hAmeBjLuo=";
 
   nativeBuildInputs = [installShellFiles scdoc];
 


### PR DESCRIPTION
Pretty self-explanatory.

Just want to get rid of the convenience type that I defined for Cobra completion functions, so this upgrades the Cobra dependency to bring that type in, and also for some bug fixes.

Changelog for Cobra, `1.8.1 -> 1.9.1` :: https://github.com/spf13/cobra/compare/v1.8.1...v1.9.1