### PR TITLE
fix(module): use normal import call for exposing module in default.nix

### DIFF
--- a/flake-compat.nix
+++ b/flake-compat.nix
@@ -1,0 +1,18 @@
+let
+  flakeSelf =
+    (
+      import
+      (
+        let
+          lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+        in
+          fetchTarball {
+            url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+            sha256 = lock.nodes.flake-compat.locked.narHash;
+          }
+      )
+      {src = ./.;}
+    )
+    .outputs;
+in
+  flakeSelf


### PR DESCRIPTION
`lib.importApply` was causing an infinite recursion for some unknown reason in `default.nix` for the module export, but this function does not currently cause issues in the flake.

Tested with the following minimal example `configuration.nix`:

```nix
{pkgs, ...}: let
  # In pure evaluation mode, always use a full Git commit hash instead of a branch name.
  nixos-cli-url = "https://github.com/nix-community/nixos-cli/archive/ac75350abb4b09b7d761cfb5ad4ce3d0c514efb9.tar.gz";
  nixos-cli = import "${builtins.fetchTarball nixos-cli-url}" {inherit pkgs;};
in {
  imports = [nixos-cli.module];

  services.nixos-cli = {
    enable = true;
    package = nixos-cli.nixosLegacy;
    config = {
      # Other configuration for nixos-cli
    };
  };

  nix.settings = {
    substituters = ["https://watersucks.cachix.org"];
    trusted-public-keys = [
      "watersucks.cachix.org-1:6gadPC5R8iLWQ3EUtfu3GFrVY7X6I4Fwz/ihW25Jbv8="
    ];
  };

  fileSystems = {
    "/" = {
      device = "/dev/vda2";
      fsType = "ext4";
    };
    "/boot/efi" = {
      device = "/dev/vda1";
      fsType = "vfat";
    };
  };

  boot.loader = {
    grub = {
      enable = true;
      efiSupport = true;
      device = "nodev";
    };
  };

  system.stateVersion = "25.05";
}
```

Closes #77.