### PR TITLE
feat(module): use legacy package by default when imported through default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,5 +5,10 @@ in {
 
   # Do not use lib.importApply here for better error tracking, since
   # it causes an infinite recursion for a currently unknown reason.
-  module = import ./module.nix flakeSelf;
+  module = import ./module.nix {
+    self = flakeSelf;
+    # If someone is using default.nix for imports, it's likely that
+    # they will also be using the legacy package on their system.
+    useFlakePkg = false;
+  };
 }

--- a/doc/src/installation.md
+++ b/doc/src/installation.md
@@ -66,8 +66,8 @@ Then, enable the module.
 }
 ```
 
-The default package is flake-enabled, so the `services.nixos-cli.package` option
-does not need to be specified.
+The default package is flake-enabled in this setup, so the
+`services.nixos-cli.package` option does not need to be specified.
 
 ### Legacy
 
@@ -88,7 +88,6 @@ in {
 
   services.nixos-cli = {
     enable = true;
-    package = nixos-cli.nixosLegacy;
     config = {
       # Other configuration for nixos-cli
     };
@@ -98,12 +97,9 @@ in {
 }
 ```
 
-NOTE: Use the `nixosLegacy` package. Specifying the `services.nixos-cli.package`
-option is required for legacy configurations, due to the fact that the default
-package is for flake configurations only. If there is a reliable way to detect
-if a configuration is flake-enabled, please file an
-[issue](https://github.com/nix-community/nixos-cli/issues/new/choose) so that
-this requirement can be removed.
+NOTE: By default, importing like this will use the `nixosLegacy` package by
+default, so there is no need to specify the `services.nixos-cli.package`
+attribute manually in this setup unless overriding something.
 
 ## Cache
 

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,6 @@
       };
     });
 
-    nixosModules.nixos-cli = lib.modules.importApply ./module.nix self;
+    nixosModules.nixos-cli = lib.modules.importApply ./module.nix {inherit self;};
   };
 }

--- a/module.nix
+++ b/module.nix
@@ -1,4 +1,7 @@
-self: {
+{
+  self,
+  useFlakePkg ? true,
+}: {
   options,
   config,
   pkgs,
@@ -17,7 +20,10 @@ in {
 
     package = lib.mkOption {
       type = types.package;
-      default = self.packages.${pkgs.system}.nixos;
+      default =
+        if useFlakePkg
+        then self.packages.${pkgs.system}.nixos
+        else self.packages.${pkgs.system}.nixosLegacy;
       description = "Package to use for nixos-cli";
     };
 


### PR DESCRIPTION
For legacy systems, `services.nixos-cli.package` needed to be specified manually, since it used the flake package by default.

This changes the default for the option depending on if it was exposed through the flake or through `default.nix`:

- If imported using the flake, it will use the flake-enabled `nixos` package
- If imported using `default.nix`, it will use the non-flake-enabled `nixosLegacy` package

I added a small note specifying this distinction in the installation instructions in the documentation as well.