### PR TITLE
docs: add comparisons page, update references to projects

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -10,5 +10,6 @@
 # Community
 
 - [FAQ](faq.md)
+- [Comparisons](comparisons.md)
 - [Contributing](contributing.md)
 - [Roadmap](roadmap.md)

--- a/doc/src/comparisons.md
+++ b/doc/src/comparisons.md
@@ -1,0 +1,42 @@
+# Comparisons to Existing NixOS Tools
+
+## [`nh`](https://github.com/nix-community/nh)
+
+`nh` is a more popular application in this realm, perhaps because it looked
+prettier due to the earlier `nix-output-monitor` and `nvd` integration, and is
+significantly older than `nixos-cli`.
+
+However, I prefer to keep the focus on NixOS here, while `nh` tries to be a
+unified `rebuild` + `switch` manager for multiple OSes. That's the biggest
+difference.
+
+`nixos-cli` also has more features than `nh` for NixOS-based machines, so that's
+a plus.
+
+In the future, I may want to write similar CLIs to `nixos-cli` as replacements
+for the current `darwin-rebuild` and `home-manager` scripts, but this is purely
+imaginative for the time being. My personal belief is that these are
+fundamentally separate projects with vaguely similar, but disparate concerns,
+and in my opinion, should be kept that way.
+
+## [`nixos-rebuild-ng`](https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/ni/nixos-rebuild-ng) + [`switch-to-configuration-ng`](https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/sw/switch-to-configuration-ng)
+
+The big differences:
+
+- They mimic the existing `nixos-rebuild.sh` project 1:1 when it comes to
+  features
+- They're two separate projects still written in two separate languages
+- They are developed in the `nixpkgs` tree, so it's harder to track progress
+
+`nixos-cli` intends to go much further than these. The interface is much more
+approachable, and the development is done out-of-tree, which makes it easier to
+separate concerns.
+
+Also, the plan in the future is to have a `nixos activate` command that is a
+self-contained drop-in replacement for `switch-to-configuration` functionality,
+rather than being two separate projects. The progress for this is tracked in
+[this GitHub issue](https://github.com/nix-community/nixos-cli/issues/55).
+
+Also, the `nixos-rebuild-ng` project is written in Python, which would require a
+Python runtime as a builtin dependency for base NixOS systems with it, while
+`nixos-cli` only requires the Go compiler.

--- a/doc/src/faq.md
+++ b/doc/src/faq.md
@@ -6,17 +6,10 @@ Yes! I will be writing an RFC to see if people are interested in this.
 
 That's my ultimate goal, anyway.
 
-## What about [`nh`](https://github.com/nix-community/nh)? Isn't that better since it supports more OSes?
+## Aren't there other people doing what you're doing?
 
-`nh` is a more popular application in this realm, perhaps because it looked
-prettier due to the earlier `nix-output-monitor` and `nvd` integration, and is
-significantly older than `nixos-cli`.
-
-However, I prefer to keep the focus on NixOS here, while `nh` tries to be a
-unified `rebuild` + `switch` manager for multiple OSes. That's the difference.
-
-`nixos-cli` also has more features than `nh` for NixOS-based machines, so that's
-a plus.
+Yes! Check the [comparisons](./comparisons.md) page for a listing of there tools
+as well as some pros/cons to each one.
 
 ## What about `home-manager` and `nix-darwin`? Will you support those systems?
 
@@ -35,14 +28,11 @@ same, but the options are different, and I'm lazy. So no.
 
 ## Can the option search work with other sources?
 
-It's theoretically possible, as long as the modules can be evaluated with
-`lib.evalModules`. As such, `home-manager`, `nix-darwin`, and even `flake-parts`
-are possible to do!
+Yes! However, this has been moved to a separate tool called
+[`optnix`](https://github.com/water-sucks/optnix).
 
-However, this tends to significantly increase evaluation time, and will depend
-on the system to eval. I plan to break out the option search UI into a separate
-project that can be more generalized, and add it back to this one as a plugin of
-sorts.
+`nixos option -i` actually uses `optnix` as a library within its code, so it is
+exactly the same UX.
 
 ## More questions?
 

--- a/doc/src/introduction.md
+++ b/doc/src/introduction.md
@@ -5,11 +5,14 @@
 
 ## Why?
 
-NixOS tooling today is fragmented across large, aging shell and Perl scripts
-that are difficult to maintain or extend. Prolific examples include:
+NixOS tooling today is fragmented across large, aging shell and other assorted
+scripts/projects that are difficult to maintain or extend. Prolific examples
+include:
 
 - [`nixos-rebuild.sh`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh)
-- [`switch-to-configuration.pl`](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/system/activation/switch-to-configuration.pl)
+  (a mess of convoluted Bash)
+- [`switch-to-configuration-ng`](https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/sw/switch-to-configuration-ng),
+  (a Rust project), as well as the old implementation in Perl
 
 These tools contain deep functionality, but much of it is hidden, hard to
 modify, or locked behind poor ergonomics.
@@ -34,6 +37,9 @@ including (but not limited to the following)
 - Creating a self-contained NixOS manager binary that includes routine scripts
   such as `switch-to-configuration` activation functionality
 - Plugins for further NixOS tooling to be developed out-of-tree
+
+Check the [comparisons](./comparisons.md) page for an overview of how this tool
+differs from existing ecosystem tools.
 
 ## Key Features
 


### PR DESCRIPTION
This PR creates a dedicated comparisons section to existing tools in the NixOS ecosystem that are direct competitors to `nixos-cli`.

Also, this updates/adds references to existing projects such as `optnix`, `switch-to-configuration-ng`, and other projects.