### PR TITLE
fix(nixopts): remove redundant -- from -I flag construction

### DIFF
--- a/internal/cmd/nixopts/nixopts.go
+++ b/internal/cmd/nixopts/nixopts.go
@@ -98,7 +98,7 @@ func AddNoNetNixOption(cmd *cobra.Command, dest *bool) {
 }
 
 func AddIncludesNixOption(cmd *cobra.Command, dest *[]string) {
-	addNixOptionStringArray(cmd, dest, "--include", "I", "Add path to list of locations to look up <...> file names")
+	addNixOptionStringArray(cmd, dest, "include", "I", "Add path to list of locations to look up <...> file names")
 }
 
 func AddMaxJobsNixOption(cmd *cobra.Command, dest *int) {


### PR DESCRIPTION
The `--include` flag that gets passed through to Nix was declared incorrectly and had an extra `--` at the beginning, and thus was not getting converted to the raw Nix flags at all and was being skipped.