### PR TITLE
fix(configuration): use dirname for configuration if path is to a direct file

### DIFF
--- a/internal/configuration/legacy.go
+++ b/internal/configuration/legacy.go
@@ -77,6 +77,8 @@ func FindLegacyConfiguration(log *logger.Logger, includes []string, verbose bool
 		if info.IsDir() {
 			return nil, fmt.Errorf("%v is a directory, not a file", defaultNix)
 		}
+	} else {
+		configuration = filepath.Dir(configuration)
 	}
 
 	return &LegacyConfiguration{


### PR DESCRIPTION
Previously, the `LegacyConfiguration` instantiation was provided a `ConfigDirname` that was an exact copy of the `nixos-config` entry in the NIX_PATH. However, this can sometimes point to a file like `/etc/nixos/configuration.nix`, rather than a directory.

If this is the case, use the directory that this file is located in as the configuration location.

Closes #82.