### PR TITLE
fix(init): call nixpkgs version function from build opts

### DIFF
--- a/cmd/init/generate.go
+++ b/cmd/init/generate.go
@@ -221,7 +221,7 @@ func generateConfigNix(log *logger.Logger, cfg *settings.Settings, virtType Virt
 		xserverConfig,
 		cfg.Init.DesktopConfig,
 		cfg.Init.ExtraConfig,
-		build.NixpkgsVersion,
+		build.NixpkgsVersion(),
 	), nil
 }
 


### PR DESCRIPTION
This caused a function closure to be printed when formatting the state version entry in `configuration.nix`.