### PR TITLE
feat(settings): suppress the no settings warning based on env var

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -63,8 +63,11 @@ func mainCommand() (*cobra.Command, error) {
 
 	cfg, err := settings.ParseSettings(configLocation)
 	if err != nil {
-		log.Error(err)
-		log.Warn("proceeding with defaults only, you have been warned")
+		if os.Getenv("NIXOS_CLI_SUPPRESS_NO_SETTINGS_WARNING") == "" {
+			log.Error(err)
+			log.Warn("proceeding with defaults only, you have been warned")
+		}
+
 		cfg = settings.NewSettings()
 	}
 

--- a/doc/man/nixos-cli-env.5.scd
+++ b/doc/man/nixos-cli-env.5.scd
@@ -75,6 +75,11 @@ Among other things.
 	Show log messages for when developing TUIs. Only useful for during
 	development.
 
+*NIXOS_CLI_SUPPRESS_NO_SETTINGS_WARNING*
+	Suppress the settings warning. Useful for non-NixOS systems where there is
+	no settings file configured by default and the warnings get noisy/clutter
+	logs.
+
 # SEE ALSO
 
 *nixos-cli-config(5)*


### PR DESCRIPTION
Sometimes, on systems where a `config.toml` is expected not to exist, the warning about no configuration existing seems to pop up quite a lot, due to its init being so early in the program.

This introduces an environment variable that can suppress these warnings for clearer output, especially on systems where a settings file is expected to _not_ exist, such as on installers or on non-NixOS systems.