### PR TITLE
feat(apply): pass NIXOS_GENERATION_TAG through if it is set

### DIFF
--- a/doc/man/nixos-cli-env.5.scd
+++ b/doc/man/nixos-cli-env.5.scd
@@ -65,6 +65,10 @@ Among other things.
 		environment variable, if the _nixos-config=<PATH>_ attribute is
 		specified there.
 
+*NIXOS_GENERATION_TAG*
+	A description for the generation. Usually set by default through the *-t*
+	flag in *nixos apply* for child commands.
+
 *NIXOS_CLI_DISABLE_STEPS*
 	Disable showing visual steps with the logger. These "steps" get converted to
 	information logs internally if this is set.

--- a/module.nix
+++ b/module.nix
@@ -98,6 +98,7 @@ in {
       # `nixos apply`. This is required in order to keep ownership across
       # automatic re-exec as root.
       Defaults env_keep += "NIXOS_CONFIG"
+      Defaults env_keep += "NIXOS_GENERATION_TAG"
       Defaults env_keep += "NIXOS_CLI_CONFIG"
     '';
   };

--- a/module.nix
+++ b/module.nix
@@ -100,6 +100,9 @@ in {
       Defaults env_keep += "NIXOS_CONFIG"
       Defaults env_keep += "NIXOS_GENERATION_TAG"
       Defaults env_keep += "NIXOS_CLI_CONFIG"
+      Defaults env_keep += "NIXOS_CLI_DISABLE_STEPS"
+      Defaults env_keep += "NIXOS_CLI_DEBUG_MODE"
+      Defaults env_keep += "NIXOS_CLI_SUPPRESS_NO_SETTINGS_WARNING"
     '';
   };
 }


### PR DESCRIPTION
If someone wants to use a generation tag for an extended period of time (i.e. for testing), it's rather tedious to type in every time `nixos apply` is ran, even if using it through command history.

This allows users to set the `NIXOS_GENERATION_TAG` variable that is already used internally for building the configuration with `nix` for describing generations.