### PR TITLE
feat(init): always use release number from nixpkgs

### DIFF
--- a/cmd/init/generate.go
+++ b/cmd/init/generate.go
@@ -226,7 +226,15 @@ func generateConfigNix(log *logger.Logger, cfg *settings.Settings, virtType Virt
 }
 
 func generateFlakeNix() string {
-	nixpkgsInputLine := fmt.Sprintf(`nixpkgs.url = "github:NixOS/nixpkgs/release-%v";`, build.NixpkgsVersion())
+	var branchName string
+
+	if version := build.NixpkgsVersion(); version != "" {
+		branchName = fmt.Sprintf("release-%v", version)
+	} else {
+		branchName = "nixos-unstable"
+	}
+
+	nixpkgsInputLine := fmt.Sprintf(`nixpkgs.url = "github:NixOS/nixpkgs/%s";`, branchName)
 	return fmt.Sprintf(flakeNixTemplate, nixpkgsInputLine)
 }
 

--- a/package.nix
+++ b/package.nix
@@ -22,6 +22,7 @@ buildGoModule (finalAttrs: {
     COMMIT_HASH = revision;
     FLAKE = lib.boolToString flake;
     VERSION = finalAttrs.version;
+    NIXPKGS_REVISION = lib.trivial.release;
   };
 
   buildPhase = ''


### PR DESCRIPTION
Before, I would need to update the nixpkgs version for the `init` subcommand to match the latest version of `nixpkgs`.

However, this is a bad idea, since I'm stupid and forgetful such that I managed to forget about this for a full three months.

So, now that I know that our glorious Lord and Savior `pkgs.lib.trivial.release` exists, I can forget about this once and for all.