### PR TITLE
docs: update supported shells for completion

### DIFF
--- a/doc/src/overview.md
+++ b/doc/src/overview.md
@@ -173,7 +173,10 @@ Supported shells:
 - `bash`
 - `zsh`
 - `fish`
+- `nushell`
+- `elvish`
+- `xonsh`
 
 If you want support for another shell, file an issue. However, this support is
-provided by [Cobra](https://github.com/spf13/cobra), and as such, support will
-probably need to be implemented upstream before this is possible.
+provided by [Carapace](https://github.com/carapace-sh/carapace), and as such,
+support will probably need to be implemented upstream before this is possible.


### PR DESCRIPTION
This was meant to go with the [previous PR](https://github.com/nix-community/nixos-cli/pull/99), but completely forgot to update the docs