### PR TITLE
fix: resolve golangci-lint warnings, add to CI checks

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,6 +31,9 @@ jobs:
           nix develop .# -c make
           nix develop .# -c make FLAKE=false
 
+      - name: Run checks
+        run: nix develop .# -c make check
+
       - name: Run tests
         run: nix develop .# -c make test
 

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ clean:
 	go clean
 	rm -rf site/ man/
 
+.PHONY: check
+check:
+	golangci-lint run
+
 .PHONY: test
 test:
 	@echo "running tests..."

--- a/cmd/generation/list/tui.go
+++ b/cmd/generation/list/tui.go
@@ -116,7 +116,7 @@ func (d generationItemDelegate) Render(w io.Writer, m list.Model, index int, lis
 		}
 	}
 
-	fmt.Fprint(w, fn(str))
+	_, _ = fmt.Fprint(w, fn(str))
 }
 
 type endAction interface {

--- a/cmd/info/info.go
+++ b/cmd/info/info.go
@@ -92,8 +92,8 @@ func prettyPrintGenInfo(g *generation.Generation) {
 		version = "NixOS (unknown version)"
 	}
 
-	titleColor.Printf("%v\n", version)
-	titleColor.Println(strings.Repeat("-", len(version)))
+	_, _ = titleColor.Printf("%v\n", version)
+	_, _ = titleColor.Println(strings.Repeat("-", len(version)))
 
 	printKey("Generation")
 	fmt.Println(g.Number)

--- a/cmd/init/cpuinfo.go
+++ b/cmd/init/cpuinfo.go
@@ -48,7 +48,7 @@ func getCPUInfo(log *logger.Logger) *CPUInfo {
 		return result
 	}
 
-	defer cpuinfoFile.Close()
+	defer func() { _ = cpuinfoFile.Close() }()
 
 	s := bufio.NewScanner(cpuinfoFile)
 	s.Split(bufio.ScanLines)

--- a/cmd/init/filesystems.go
+++ b/cmd/init/filesystems.go
@@ -42,7 +42,7 @@ func findSwapDevices(log *logger.Logger) []string {
 		log.Warnf("failed to open swap device list %v: %v", swapDeviceListFilename, err)
 		return swapDevices
 	}
-	defer swapDeviceList.Close()
+	defer func() { _ = swapDeviceList.Close() }()
 
 	s := bufio.NewScanner(swapDeviceList)
 	s.Split(bufio.ScanLines)
@@ -54,11 +54,12 @@ func findSwapDevices(log *logger.Logger) []string {
 		swapFilename := fields[0]
 		swapType := fields[1]
 
-		if swapType == "partition" {
+		switch swapType {
+		case "partition":
 			swapDevices = append(swapDevices, findStableDevPath(swapFilename))
-		} else if swapType == "file" {
+		case "file":
 			log.Infof("skipping swap file %v, specify in configuration manually if needed", swapFilename)
-		} else {
+		default:
 			log.Warnf("unsupported swap type %v for %v; do not specify in configuration", swapType, swapFilename)
 		}
 	}
@@ -77,7 +78,7 @@ func findFilesystems(log *logger.Logger, rootDir string) []Filesystem {
 		log.Warnf("failed to open swap device list %v: %v", mountedFilesystemListFilename, err)
 		return filesystems
 	}
-	defer mountList.Close()
+	defer func() { _ = mountList.Close() }()
 
 	s := bufio.NewScanner(mountList)
 	s.Split(bufio.ScanLines)

--- a/internal/cmd/utils/utils.go
+++ b/internal/cmd/utils/utils.go
@@ -12,17 +12,16 @@ func SetHelpFlagText(cmd *cobra.Command) {
 	cmd.Flags().BoolP("help", "h", false, "Show this help menu")
 }
 
-var CommandError = errors.New("command error")
+var ErrCommand = errors.New("command error")
 
-// Replace a returned error with the generic CommandError, and.
+// Replace a returned error with the generic `ErrCommand`, and.
 // exit with a non-zero exit code. This is to avoid extra error
 // messages being printed when a command function defined with
 // RunE returns a non-nil error.
 func CommandErrorHandler(err error) error {
 	if err != nil {
 		os.Exit(1)
-
-		return CommandError
+		return ErrCommand
 	}
 	return nil
 }

--- a/internal/time/systemd.go
+++ b/internal/time/systemd.go
@@ -14,7 +14,7 @@ func DurationFromTimeSpan(span string) (time.Duration, error) {
 	}
 
 	for _, c := range span {
-		if !(unicode.IsDigit(c) || unicode.IsLetter(c) || c == ' ') {
+		if !unicode.IsDigit(c) && !unicode.IsLetter(c) && c != ' ' {
 			return 0, fmt.Errorf("invalid character %v", c)
 		}
 	}


### PR DESCRIPTION
This adds the golangci-lint checker to CI for pull requests, and also resolves any remaining warnings that are currently emitted using it.