### PR TITLE
fix: Resolve symlink before FlakeRefFromEnv

### DIFF
--- a/internal/configuration/flake.go
+++ b/internal/configuration/flake.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/nix-community/nixos-cli/internal/cmd/nixopts"
@@ -22,15 +23,28 @@ type FlakeRef struct {
 func FlakeRefFromString(s string) *FlakeRef {
 	split := strings.Index(s, "#")
 
+	var uri string
+	if split > -1 {
+		uri = s[:split]
+	} else {
+		uri = s
+	}
+
+	if _, err := os.Stat(uri); err == nil {
+		if resolved, err := filepath.EvalSymlinks(uri); err == nil {
+			uri = resolved
+		}
+    }
+
 	if split > -1 {
 		return &FlakeRef{
-			URI:    s[:split],
+			URI:    uri,
 			System: s[split+1:],
 		}
 	}
 
 	return &FlakeRef{
-		URI:    s,
+		URI:    uri,
 		System: "",
 	}
 }


### PR DESCRIPTION
Greetings!

Currently, `nixos-cli` subcommands that execute the `nix` command under the hood fail to [find flake.nix inside symlinked directories](https://github.com/NixOS/nix/issues/8013) (for example, `ln -s ~/.config/nixos /etc; nixos apply -dv`). However, `nixos-rebuild{,-ng}` work fine in the same setup.

This change ensures that the path is resolved to the real directory before being passed to `FlakeRefFromEnv` using `filepath.EvalSymlinks`, allowing symlinked configuration directories to work transparently.