### PR TITLE
refactor(nix): more package/module renames/modernization

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,28 @@ All dependencies for this project are neatly provided in a Nix shell. Run
 `nix develop .#` or use [`direnv`](https://direnv.net) to automatically drop
 into this Nix shell on changing to this directory.
 
-In order to build both packages at the same time, run
+### Nix Package
+
+The Nix package is divided into two variants: an unwrapped variant and a wrapped
+one. The wrapped one adds dependencies such as Nix itself to the PATH, while the
+unwrapped package is the one that gets rebuilt when the source
+code/documentation is changed. This is done to avoid excessive rebuilds if Nix
+itself or other runtime dependencies of `nixos-cli` is changed.
+
+There are four packages provided as flake package outputs:
+
+- `nixos-cli`
+- `nixos-cli-legacy`
+- `nixos-cli-unwrapped`
+- `nixos-cli-legacy-uwnrapped`
+
+Only use the unwrapped packages when absolutely necessary.
+
+In order to build both wrapped packages at the same time, run
 `nix build .#{nixos-cli,nixos-cli-legacy}`.
 
 Legacy-style `nix-build` and `nix-shell` can also be used; this uses
-`flake-compat` under the hood.
+[`flake-compat`](https://github.com/NixOS/flake-compat) under the hood.
 
 ### Tests
 
@@ -99,16 +116,16 @@ Check the build script source for more information on how to work with this.
 
 Version numbers are handled using [semantic versioning](https://semver.org/).
 They are also managed using Git tags; every version has a Git tag named with the
-version; the tag name does not have a preceding "v".
+version; the tag name does not have a preceding letter "v".
 
 Non-released builds have a version number that is suffixed with `"-dev"`. As
 such, a tag should always exist on a version number change (which removes the
-suffix), and the very next commit will re-introduce the suffix.
+suffix), and the very next commit will reintroduce the suffix.
 
 Once a tag is created and pushed, create a GitHub release off this tag.
 
-The version number is managed inside the Nix derivation at
-[package.nix](./nix/package.nix).
+The version number is managed inside the Nix derivation inside the
+[nix/package](./nix/package/unwrapped.nix) directory.
 
 ### CI
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ with the following Makefile rules:
 `make gen-site` generates two files:
 
 - Documentation for all available settings in `config.toml`
-- Module documentation for `services.nixos-cli`, built using
+- Module documentation for `programs.nixos-cli`, built using
   [`optnix`](https://github.com/water-sucks/optnix)
 
 The rest of the site documentation files are located in [doc/man](./doc/src).

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ All dependencies for this project are neatly provided in a Nix shell. Run
 into this Nix shell on changing to this directory.
 
 In order to build both packages at the same time, run
-`nix build .#{nixos,nixosLegacy}`.
+`nix build .#{nixos-cli,nixos-cli-legacy}`.
 
 Legacy-style `nix-build` and `nix-shell` can also be used; this uses
 `flake-compat` under the hood.

--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,8 @@ in {
     (flakeSelf.packages.${system})
     nixos-cli
     nixos-cli-legacy
+    nixos-cli-unwrapped
+    nixos-cli-legacy-unwrapped
     # Also inherit aliases, to be removed later.
     nixos
     nixosLegacy

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,14 @@
   flakeSelf = (import ./nix/flake-compat.nix).outputs;
   inherit (pkgs.stdenv.hostPlatform) system;
 in {
-  inherit (flakeSelf.packages.${system}) nixos nixosLegacy;
+  inherit
+    (flakeSelf.packages.${system})
+    nixos-cli
+    nixos-cli-legacy
+    # Also inherit aliases, to be removed later.
+    nixos
+    nixosLegacy
+    ;
 
   # Do not use lib.importApply here for better error tracking, since
   # it causes an infinite recursion for a currently unknown reason.

--- a/doc/book.toml
+++ b/doc/book.toml
@@ -1,6 +1,5 @@
 [book]
 authors = ["Varun Narravula"]
 language = "en"
-multilingual = false
 src = "src"
 title = "nixos-cli"

--- a/doc/build.go
+++ b/doc/build.go
@@ -104,7 +104,7 @@ func generateModuleDoc(filename string, rev string) error {
 
 	var options []option.NixosOption
 	for _, o := range fullOptionSrc {
-		if !strings.HasPrefix(o.Name, "services.nixos-cli") {
+		if !strings.HasPrefix(o.Name, "programs.nixos-cli") {
 			continue
 		}
 

--- a/doc/src/installation.md
+++ b/doc/src/installation.md
@@ -57,7 +57,7 @@ Then, enable the module.
 { config, pkgs, ... }:
 
 {
-  services.nixos-cli = {
+  programs.nixos-cli = {
     enable = true;
     config = {
       # Whatever settings desired.
@@ -67,7 +67,7 @@ Then, enable the module.
 ```
 
 The default package is flake-enabled in this setup, so the
-`services.nixos-cli.package` option does not need to be specified.
+`programs.nixos-cli.package` option does not need to be specified.
 
 ### Legacy
 
@@ -86,7 +86,7 @@ in {
     nixos-cli.module
   ];
 
-  services.nixos-cli = {
+  programs.nixos-cli = {
     enable = true;
     config = {
       # Other configuration for nixos-cli
@@ -98,7 +98,7 @@ in {
 ```
 
 NOTE: By default, importing like this will use the `nixosLegacy` package by
-default, so there is no need to specify the `services.nixos-cli.package`
+default, so there is no need to specify the `programs.nixos-cli.package`
 attribute manually in this setup unless overriding something.
 
 ## Cache

--- a/doc/src/installation.md
+++ b/doc/src/installation.md
@@ -22,7 +22,7 @@ NixOS has quite a large ecosystem of tools, and can be quite the moving target
 in terms of features, so `nixos-unstable` and the current stable release are the
 only actively supported releases.
 
-## Adding To Configuration
+## Adding to Configuration
 
 Use the following sections depending on whether or not your systems are
 configured with flakes or legacy-style configurations.
@@ -97,7 +97,7 @@ in {
 }
 ```
 
-NOTE: By default, importing like this will use the `nixosLegacy` package by
+NOTE: By default, importing like this will use the `nixos-cli-legacy` package by
 default, so there is no need to specify the `programs.nixos-cli.package`
 attribute manually in this setup unless overriding something.
 
@@ -157,10 +157,10 @@ Use `nix develop` (flake-enabled package by default):
 $ nix shell github:nix-community/nixos-cli
 ```
 
-Alternative using legacy-style `nix-shell` and the `nixosLegacy` package:
+Alternative using legacy-style `nix-shell` and the `nixos-cli-legacy` package:
 
 ```sh
-$ nix-shell -E 'with import (fetchTarball "https://github.com/nix-community/nixos-cli/archive/refs/heads/main.tar.gz") {}; nixosLegacy'
+$ nix-shell -E 'with import (fetchTarball "https://github.com/nix-community/nixos-cli/archive/refs/heads/main.tar.gz") {}; nixos-cli-legacy'
 ```
 
 ## Rebuild

--- a/doc/src/overview.md
+++ b/doc/src/overview.md
@@ -94,9 +94,9 @@ automatically escalates to `root` using the command defined in the
 user that has the `NOPASSWD` `sudo` rule.
 
 In order to access remote machines, it is recommended to use SSH keys managed by
-an SSH agent, or to provide a key via the `ssh.private_key_cmd` setting. Password
-access is supported, but not recommended, and can be buggy. If you find any issues,
-report them on the issue tracker.
+an SSH agent, or to provide a key via the `ssh.private_key_cmd` setting.
+Password access is supported, but not recommended, and can be buggy. If you find
+any issues, report them on the issue tracker.
 
 ### `nixos-enter`
 
@@ -142,12 +142,11 @@ Cool, right?
 
 By default, `nixos option` uses this TUI.
 
-To use normal, non-interactive output for a specific option, add the `-n`
-switch.
+To use normal, noninteractive output for a specific option, add the `-n` switch.
 
 However, there is one caveat: generating the option index is an intensive
-operation; this can be precomputed on every configuration change using the
-`services.nixos-cli.prebuildOptionCache` if desired.
+operation; this can be precomputed on every configuration change by setting
+`programs.nixos-cli.option-cache.enable = true`, if desired.
 
 ## Environment Variables
 

--- a/doc/src/settings.md
+++ b/doc/src/settings.md
@@ -16,7 +16,7 @@ $ nixos --config apply.imply_impure_with_tag=false apply
 ```
 
 The preferred way to create this settings file is through the provided Nix
-module that generates the TOML using the `services.nixos-cli.config` option.
+module that generates the TOML using the `programs.nixos-cli.config` option.
 Refer to the [module documentation](./module.md) for other available options.
 
 ## Available Settings

--- a/flake.nix
+++ b/flake.nix
@@ -34,13 +34,15 @@
         ...
       }: {
         packages = {
-          default = self'.packages.nixos;
+          default = self'.packages.nixos-cli;
 
-          nixos = pkgs.callPackage ./nix/package.nix {
+          nixos-cli = pkgs.callPackage ./nix/package.nix {
             revision = self.rev or self.dirtyRev or "unknown";
           };
+          nixos = lib.warn "the 'nixos' package has been renamed to 'nixos-cli'" self'.packages.nixos-cli;
 
-          nixosLegacy = self'.packages.nixos.override {flake = false;};
+          nixos-cli-legacy = self'.packages.nixos-cli.override {flake = false;};
+          nixosLegacy = lib.warn "the 'nixosLegacy' package has been renamed to 'nixos-cli-legacy'" self'.packages.nixos-cli-legacy;
         };
 
         devShells = let

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -64,8 +64,8 @@ in {
       type = types.package;
       default =
         if useFlakePkg
-        then self.packages.${system}.nixos
-        else self.packages.${system}.nixosLegacy;
+        then self.packages.${system}.nixos-cli
+        else self.packages.${system}.nixos-cli-legacy;
       description = "Package to use for nixos-cli";
     };
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -8,7 +8,7 @@
   lib,
   ...
 }: let
-  cfg = config.services.nixos-cli;
+  cfg = config.programs.nixos-cli;
   nixosCfg = config.system.nixos;
 
   inherit (pkgs.stdenv.hostPlatform) system;
@@ -44,17 +44,20 @@
 in {
   imports = [
     (lib.mkRenamedOptionModule
-      ["services" "nixos-cli" "prebuildOptionCache"]
-      ["services" "nixos-cli" "option-cache" "enable"])
+      ["services" "nixos-cli"]
+      ["programs" "nixos-cli"])
     (lib.mkRenamedOptionModule
-      ["services" "nixos-cli" "useActivationInterface"]
-      ["services" "nixos-cli" "activation-interface" "enable"])
+      ["programs" "nixos-cli" "prebuildOptionCache"]
+      ["programs" "nixos-cli" "option-cache" "enable"])
     (lib.mkRenamedOptionModule
-      ["services" "nixos-cli" "generationTag"]
-      ["services" "nixos-cli" "generation-tag"])
+      ["programs" "nixos-cli" "useActivationInterface"]
+      ["programs" "nixos-cli" "activation-interface" "enable"])
+    (lib.mkRenamedOptionModule
+      ["programs" "nixos-cli" "generationTag"]
+      ["programs" "nixos-cli" "generation-tag"])
   ];
 
-  options.services.nixos-cli = {
+  options.programs.nixos-cli = {
     enable = lib.mkEnableOption "unified NixOS tooling replacement for nixos-* utilities";
 
     package = lib.mkOption {
@@ -155,7 +158,7 @@ in {
         rules are configured for the `:wheel` group only.
 
         If you need more flexible definitions for these rules, consider using
-        the default value of `services.nixos-cli.preserve-env` as a reference list
+        the default value of `programs.nixos-cli.preserve-env` as a reference list
         of default variables that should be preserved across this boundary.
 
         It is recommended to use this option for any extra environment variables to
@@ -202,7 +205,7 @@ in {
       '';
 
       security.doas.extraRules = let
-        isDefaultList = cfg.preserve-env == options.services.nixos-cli.preserve-env.default;
+        isDefaultList = cfg.preserve-env == options.programs.nixos-cli.preserve-env.default;
 
         # Remove SSH_AUTH_SOCK from the default list if it equals the
         # defaults, since SSH_AUTH_SOCK is present and kept by the default

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -55,6 +55,9 @@ in {
     (lib.mkRenamedOptionModule
       ["programs" "nixos-cli" "generationTag"]
       ["programs" "nixos-cli" "generation-tag"])
+    (lib.mkRenamedOptionModule
+      ["programs" "nixos-cli" "config"]
+      ["programs" "nixos-cli" "settings"])
   ];
 
   options.programs.nixos-cli = {
@@ -69,10 +72,10 @@ in {
       description = "Package to use for nixos-cli";
     };
 
-    config = lib.mkOption {
+    settings = lib.mkOption {
       type = tomlFormat.type;
       default = {};
-      description = "Configuration for nixos-cli, in TOML format";
+      description = "Configuration written to /etc/nixos-cli/config.toml";
       apply = prev: let
         # Inherit this from the old nixos-generate-config attrs. Easy to deal with, for now.
         desktopConfig = lib.concatStringsSep "\n" config.system.nixos-generate-config.desktopConfiguration;
@@ -180,7 +183,7 @@ in {
       environment.systemPackages = [cfg.package];
 
       environment.etc."nixos-cli/config.toml".source =
-        tomlFormat.generate "nixos-cli-config.toml" cfg.config;
+        tomlFormat.generate "nixos-cli-config.toml" cfg.settings;
 
       # Hijack system builder commands to insert a `nixos-version.json` file at the root.
       system.systemBuilderCommands = let

--- a/nix/package/default.nix
+++ b/nix/package/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  symlinkJoin,
+  makeBinaryWrapper,
+  nix,
+  nixos-cli-unwrapped,
+}: let
+  runtimeDeps = [
+    # Make sure that we use the Nix package we depend on, not something
+    # else from the PATH for nix-{env,instantiate,build}. This is
+    # important, because NixOS defaults the architecture of the rebuilt
+    # system to the architecture of the nix-* binaries used. So if on an
+    # amd64 system the user has an i686 Nix package in her PATH, then we
+    # would silently downgrade the whole system to be i686 NixOS on the
+    # next reboot.
+    # Credit where credit is due: this note is taken directly from nixos-rebuild-ng.
+    nix
+  ];
+in
+  symlinkJoin {
+    pname = "nixos-cli";
+    inherit (nixos-cli-unwrapped) version meta;
+
+    paths = [
+      nixos-cli-unwrapped
+    ];
+
+    nativeBuildInputs = [
+      makeBinaryWrapper
+    ];
+
+    postBuild = ''
+      wrapProgram $out/bin/nixos \
+        --prefix PATH : ${lib.makeBinPath runtimeDeps}
+    '';
+  }

--- a/nix/package/unwrapped.nix
+++ b/nix/package/unwrapped.nix
@@ -8,19 +8,19 @@
   flake ? true,
 }:
 buildGoModule (finalAttrs: {
-  pname = "nixos-cli";
+  pname = "nixos-cli-unwrapped";
   version = "0.15.0-dev";
 
   src = lib.fileset.toSource {
-    root = ../.;
+    root = ../../.;
     fileset = lib.fileset.unions [
-      ../go.mod
-      ../go.sum
-      ../Makefile
-      ../main.go
-      ../cmd
-      ../doc
-      ../internal
+      ../../go.mod
+      ../../go.sum
+      ../../Makefile
+      ../../main.go
+      ../../cmd
+      ../../doc
+      ../../internal
     ];
   };
 

--- a/nix/tests/example.test.nix
+++ b/nix/tests/example.test.nix
@@ -7,7 +7,7 @@ pkgs.testers.runNixOSTest {
   name = "example-test";
   nodes.machine1 = _: {
     imports = [self.nixosModules.nixos-cli];
-    services.nixos-cli.enable = true;
+    programs.nixos-cli.enable = true;
   };
 
   testScript = ''


### PR DESCRIPTION
This PR continues the renaming efforts done in #183, and renames the entire `services.nixos-cli` module to `programs.nixos-cli` instead, since the `nixos-cli` program itself isn't really a system service, nor does it have one to speak of.

It also renames the `config` option to `settings`, since `config` is usually designated for raw configuration, and `settings` for structured Nix config, as per `nixpkgs` conventions.

Additionally, it completes the rename of the actual packages from bare `nixos` (which was the name of the binary and original project, but wasn't very descriptive), to `nixos-cli` and `nixos-cli-legacy`, and wraps the `nixos-cli` package with the latest Nix as a runtime dependency, as to prevent Nix from bringing in packages for the wrong platform and so that more recent Nix versions can be relied on.