### PR TITLE
feat(apply): add --eval-only flag 

### DIFF
--- a/doc/man/nixos-cli-apply.1.scd
+++ b/doc/man/nixos-cli-apply.1.scd
@@ -74,6 +74,14 @@ _nixos-rebuild dry-build_
 
 	*nixos apply --dry --no-activate --no-boot*
 
+_`nix eval .#nixosConfigurations.$HOSTNAME.config.system.build.toplevel`_
+
+	*nixos apply --eval-only*
+
+	or using the default alias:
+
+	*nixos eval*
+
 Many other behaviors for _nixos-rebuild_ are in the *nixos generation*
 command tree. See *nixos-cli-generation(1)* for details.
 
@@ -157,6 +165,22 @@ global *--config* flag as such:
 	is assumed.
 
 	The list of changes is not guaranteed to be complete for dry activations.
+
+*--eval-only*
+	Only evaluate the configuration without building or activating it. This is
+	useful for checking that a NixOS configuration evaluates successfully
+	without spending time on a full build.
+
+	This is equivalent to running something like
+	_nix eval .#nixosConfigurations.$HOSTNAME.config.system.build.toplevel_
+	for flake-based configurations.
+
+	A default alias *eval* is provided, so *nixos eval* can be used as a
+	shorthand for *nixos apply --eval-only*.
+
+	Mutually exclusive with *--no-activate*, *--no-boot*,
+	*--install-bootloader*, *--store-path*, *--vm[-with-bootloader]*,
+	and *--image*.
 
 *-i*, *--image* <VARIANT>
 	Build a disk-image variant, pre-configured for the given platform/provider.

--- a/doc/man/nixos-cli-apply.1.scd
+++ b/doc/man/nixos-cli-apply.1.scd
@@ -78,10 +78,6 @@ _`nix eval .#nixosConfigurations.$HOSTNAME.config.system.build.toplevel`_
 
 	*nixos apply --eval-only*
 
-	or using the default alias:
-
-	*nixos eval*
-
 Many other behaviors for _nixos-rebuild_ are in the *nixos generation*
 command tree. See *nixos-cli-generation(1)* for details.
 
@@ -175,12 +171,7 @@ global *--config* flag as such:
 	_nix eval .#nixosConfigurations.$HOSTNAME.config.system.build.toplevel_
 	for flake-based configurations.
 
-	A default alias *eval* is provided, so *nixos eval* can be used as a
-	shorthand for *nixos apply --eval-only*.
-
-	Mutually exclusive with *--no-activate*, *--no-boot*,
-	*--install-bootloader*, *--store-path*, *--vm[-with-bootloader]*,
-	and *--image*.
+	Mutually exclusive with *--store-path*.
 
 *-i*, *--image* <VARIANT>
 	Build a disk-image variant, pre-configured for the given platform/provider.

--- a/internal/cmd/opts/opts.go
+++ b/internal/cmd/opts/opts.go
@@ -44,6 +44,7 @@ type ApplyOpts struct {
 	TargetHost            string
 	UpgradeAllChannels    bool
 	UpgradeChannels       bool
+	EvalOnly              bool
 	UseNom                bool
 	Verbose               bool
 

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -28,16 +28,13 @@ type SystemBuildOptions struct {
 }
 
 type SystemEvalOptions struct {
-	// Command-line flags that were passed for the command context.
-	CmdFlags *pflag.FlagSet
-	NixOpts  nixopts.NixOptionsSet
-	Env      map[string]string
+	NixOpts nixopts.NixOptionsSet
 }
 
 type Configuration interface {
 	SetBuilder(builder system.CommandRunner)
 	EvalAttribute(attr string) (*string, error)
-	EvalSystem(opts *SystemEvalOptions) error
+	EvalSystem(s *system.LocalSystem, buildType BuildType, opts *SystemEvalOptions) error
 	BuildSystem(buildType BuildType, opts *SystemBuildOptions) (string, error)
 }
 

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -27,9 +27,17 @@ type SystemBuildOptions struct {
 	ExtraArgs []string
 }
 
+type SystemEvalOptions struct {
+	// Command-line flags that were passed for the command context.
+	CmdFlags *pflag.FlagSet
+	NixOpts  nixopts.NixOptionsSet
+	Env      map[string]string
+}
+
 type Configuration interface {
 	SetBuilder(builder system.CommandRunner)
 	EvalAttribute(attr string) (*string, error)
+	EvalSystem(opts *SystemEvalOptions) error
 	BuildSystem(buildType BuildType, opts *SystemBuildOptions) (string, error)
 }
 

--- a/internal/configuration/flake.go
+++ b/internal/configuration/flake.go
@@ -125,15 +125,15 @@ func (f *FlakeRef) EvalAttribute(attr string) (*string, error) {
 func (f *FlakeRef) EvalSystem(s *system.LocalSystem, buildType BuildType, opts *SystemEvalOptions) error {
 	systemAttribute := f.BuildAttr(buildType.BuildAttr())
 
-	argv := []string{"eval", systemAttribute}
+	argv := []string{"nix", "eval", systemAttribute}
 
 	if opts.NixOpts != nil {
 		argv = append(argv, opts.NixOpts.ArgsForCommand(nixopts.CmdEval)...)
 	}
 
-	s.Logger().CmdArray(append([]string{"nix"}, argv...))
+	s.Logger().CmdArray(argv)
 
-	cmd := system.NewCommand("nix", argv...)
+	cmd := system.NewCommand(argv[0], argv[1:]...)
 
 	_, err := s.Run(cmd)
 	return err

--- a/internal/configuration/flake.go
+++ b/internal/configuration/flake.go
@@ -122,6 +122,26 @@ func (f *FlakeRef) EvalAttribute(attr string) (*string, error) {
 	return &value, nil
 }
 
+func (f *FlakeRef) EvalSystem(opts *SystemEvalOptions) error {
+	systemAttribute := f.BuildAttr("toplevel")
+
+	argv := []string{"nix", "eval", systemAttribute}
+
+	if opts.NixOpts != nil {
+		argv = append(argv, opts.NixOpts.ArgsForCommand(nixopts.CmdEval)...)
+	}
+
+	cmd := exec.Command(argv[0], argv[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	for k, v := range opts.Env {
+		cmd.Env = append(os.Environ(), fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return cmd.Run()
+}
+
 func (f *FlakeRef) buildLocalSystem(s *system.LocalSystem, buildType BuildType, opts *SystemBuildOptions) (string, error) {
 	nixCommand := "nix"
 	if opts.UseNom {

--- a/internal/configuration/legacy.go
+++ b/internal/configuration/legacy.go
@@ -136,15 +136,15 @@ func (l *LegacyConfiguration) EvalAttribute(attr string) (*string, error) {
 }
 
 func (l *LegacyConfiguration) EvalSystem(s *system.LocalSystem, buildType BuildType, opts *SystemEvalOptions) error {
-	argv := []string{"--eval", l.ConfigPathArg(), "-A", l.BuildAttr(buildType.BuildAttr())}
+	argv := []string{"nix-instantiate", "--eval", l.ConfigPathArg(), "-A", l.BuildAttr(buildType.BuildAttr())}
 
 	if opts.NixOpts != nil {
 		argv = append(argv, opts.NixOpts.ArgsForCommand(nixopts.CmdInstantiate)...)
 	}
 
-	s.Logger().CmdArray(append([]string{"nix-instantiate"}, argv...))
+	s.Logger().CmdArray(argv)
 
-	cmd := system.NewCommand("nix-instantiate", argv...)
+	cmd := system.NewCommand(argv[0], argv[1:]...)
 
 	_, err := s.Run(cmd)
 	return err

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -131,6 +131,7 @@ var DefaultAliases = map[string][]string{
 	"build-vm-with-bootloader": {"apply", "--no-activate", "--no-boot", "--output", "./result", "--vm-with-bootloader"},
 	"dry-build":                {"apply", "--no-activate", "--no-boot", "--dry"},
 	"dry-activate":             {"apply", "--dry"},
+	"eval":                     {"apply", "--eval-only"},
 	"list-generations":         {"generation", "list", "--table"},
 }
 


### PR DESCRIPTION

Add a new `--eval-only` flag that evaluates the NixOS configuration without building or activating it. This is useful for quickly checking that a configuration evaluates successfully.

- Add `--eval-only` flag to apply command with mutual exclusivity checks
- Implement `EvalSystem` method for both flake and legacy configurations
- Add default alias `eval` for `nixos apply --eval-only`
- Document the new flag and alias in man