### PR TITLE
refactor(settings): use better serialization methods and types

### DIFF
--- a/doc/build.go
+++ b/doc/build.go
@@ -309,13 +309,18 @@ func writeSettingsDoc(
 		if field.Type.Kind() == reflect.Struct {
 			nestedFields = append(nestedFields, nestedField{field, fieldVal, fullKey})
 		} else {
+			descriptions, exists := settings.SettingsDocs[fullKey]
+			if !exists {
+				panic("missing description for " + fullKey)
+			}
+
 			defaultVal := fieldVal.Interface()
 
-			descriptions := settings.SettingsDocs[fullKey]
 			desc := descriptions.Long
 			if desc == "" {
 				desc = descriptions.Short
 			}
+
 			generalItems = append(generalItems, configKey{fullKey, desc, defaultVal})
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/knadh/koanf/providers/rawbytes v1.0.0
 	github.com/knadh/koanf/v2 v2.3.0
 	github.com/olekukonko/tablewriter v0.0.5
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/pkg/sftp v1.13.10
 	github.com/sahilm/fuzzy v0.1.1
 	github.com/spf13/cobra v1.10.1
@@ -81,7 +82,6 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/mmcloughlin/avo v0.6.0 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pjbgf/sha1cd v0.3.1 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/skeema/knownhosts v1.3.0 // indirect

--- a/internal/settings/errors.go
+++ b/internal/settings/errors.go
@@ -2,7 +2,7 @@ package settings
 
 import "fmt"
 
-type SettingsErrors []SettingsError
+type SettingsErrors []error
 
 type SettingsError struct {
 	Field   string
@@ -11,4 +11,14 @@ type SettingsError struct {
 
 func (e SettingsError) Error() string {
 	return fmt.Sprintf("%s: %s", e.Field, e.Message)
+}
+
+type DeprecatedSettingError struct {
+	Field       string
+	Alternative string
+}
+
+func (e DeprecatedSettingError) Error() string {
+	return fmt.Sprintf(`%s: %s
+hint: %s`, e.Field, DeprecatedDocString, e.Alternative)
 }

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -92,29 +92,25 @@ func (c *ConfirmationPromptBehavior) UnmarshalText(text []byte) error {
 }
 
 type DescriptionEntry struct {
-	Short string
-	Long  string
+	Short   string
+	Long    string
+	Example any
 }
 
 const (
-	aliasExample = "```\n" + `[aliases]
-genlist = ["generation", "list"]
-switch = ["generation", "switch"]
-rollback = ["generation", "rollback"]
-` + "```\n"
-
 	confirmationInputPossibleValues = "Possible values are `default-no` (treat as a no input), `default-yes` (treat as a yes input), or `retry` (try again)."
 	deprecatedDocString             = "This setting has been deprecated, and will be removed in a future release."
-
-	sshPrivateKeyCmdExample = "```\n" + `[ssh]
-private_key_cmd = ["sh", "-c", "rbw get $NIXOS_CLI_SSH_HOST"]
-` + "```\n"
 )
 
 var SettingsDocs = map[string]DescriptionEntry{
 	"aliases": {
 		Short: "Shortcuts for long commands",
-		Long:  "Defines alternative aliases for long commands to improve user ergonomics.\nExample:\n" + aliasExample,
+		Long:  "Defines alternative aliases for long commands to improve user ergonomics.",
+		Example: map[string][]string{
+			"genlist":  {"generation", "list"},
+			"switch":   {"generation", "switch"},
+			"rollback": {"generation", "rollback"},
+		},
 	},
 	"apply": {
 		Short: "Settings for `apply` command",
@@ -229,8 +225,8 @@ var SettingsDocs = map[string]DescriptionEntry{
 		Short: "Command to run to obtain SSH private key",
 		Long: "Specifies the command to run to obtain the private key for SSH connections." +
 			" The command receives the host and user as the environment variables $NIXOS_CLI_SSH_HOST" +
-			" and $NIXOS_CLI_SSH_USER respectively, and should output a single private key to standard output." +
-			"\nExample:\n" + sshPrivateKeyCmdExample,
+			" and $NIXOS_CLI_SSH_USER respectively, and should output a single private key to standard output.",
+		Example: []string{"sh", "-c", "rbw get $NIXOS_CLI_SSH_HOST"},
 	},
 	"root_command": {
 		Short: "Command to use to promote process to root",

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -125,7 +125,7 @@ var SettingsDocs = map[string]DescriptionEntry{
 	},
 	"apply.specialisation": {
 		Short: "Name of specialisation to use by default when activating",
-		Long:  "Specifies which systemd specialisation to use when activating a configuration with 'apply'.",
+		Long:  "Specifies which specialisation to use when activating a configuration with 'apply'.",
 	},
 	"apply.use_nom": {
 		Short: "Use 'nix-output-monitor' as an alternative 'nix build' frontend",
@@ -182,6 +182,14 @@ var SettingsDocs = map[string]DescriptionEntry{
 	"init": {
 		Short: "Settings for `init` command",
 	},
+	"init.extra_attrs": {
+		Short: "Extra attributes to add to the generated configuration",
+		Long:  "Extra attributes to add to the generated configuration.nix file. Usually configured indirectly through the NixOS module.",
+	},
+	"init.extra_config": {
+		Short: "Extra Nix code to add to the generated configuration",
+		Long:  "Extra Nix code to add to the generated configuration.nix verbatim. Usually configured indirectly through the NixOS module.",
+	},
 	"init.xserver_enabled": {
 		Short: "Generate options to enable X11 display server",
 		Long:  "Controls whether X11-related services and packages are configured by default during init.",
@@ -236,6 +244,7 @@ var SettingsDocs = map[string]DescriptionEntry{
 
 func NewSettings() *Settings {
 	return &Settings{
+		Aliases:        make(map[string][]string),
 		AutoRollback:   true,
 		UseColor:       true,
 		ConfigLocation: "/etc/nixos",


### PR DESCRIPTION
When generation documentation, the metadata was often stringly typed, which made serialization of values rather hard.

This was the case for showing default values for more complex TOML types such as maps and slices, as mentioned in #185, and also for showing examples, since these were often directly embedded as markdown in the description.

Let's not even MENTION the differences between `scdoc` manpages and Markdown! That was also a huge problem with this code.

This PR solves all those problems and uses actual fields in the settings description entries for any examples and deprecation notices, and formats them depending on if they're in a Markdown page or a man page.

Additionally, it serializes all default values using the underlying `koanf` TOML serializer (`pelletier/go-toml`), so no new dependencies are introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced settings documentation with improved TOML-formatted example values and defaults for better clarity.
  * Improved deprecation warnings that provide alternative suggestions when using deprecated settings.

* **Refactor**
  * Updated internal settings validation and error handling mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->