### PR TITLE
fix(apply): standardise --eval-only output

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -354,18 +354,26 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 		nixConfig.SetBuilder(buildHost)
 
 		if opts.EvalOnly {
-			log.Step("Evaluating configuration...")
+			switch buildType.(type) {
+			case *configuration.SystemBuild:
+				log.Step("Evaluating configuration...")
+			case *configuration.ImageBuild:
+				log.Step("Evaluating image...")
+			case *configuration.VMBuild:
+				log.Step("Evaluating VM...")
+			}
 
 			evalOptions := &configuration.SystemEvalOptions{
 				NixOpts: &opts.NixOptions,
 			}
 
-			if err := nixConfig.EvalSystem(localSystem, buildType, evalOptions); err != nil {
+			drvPath, err := nixConfig.EvalSystem(localSystem, buildType, evalOptions)
+			if err != nil {
 				log.Errorf("failed to evaluate configuration: %v", err)
 				return err
 			}
 
-			log.Info("evaluation successful")
+			log.Infof("the evaluated derivation is %v", drvPath)
 			return nil
 		}
 

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -34,7 +34,7 @@ type SystemEvalOptions struct {
 type Configuration interface {
 	SetBuilder(builder system.CommandRunner)
 	EvalAttribute(attr string) (*string, error)
-	EvalSystem(s *system.LocalSystem, buildType BuildType, opts *SystemEvalOptions) error
+	EvalSystem(s *system.LocalSystem, buildType BuildType, opts *SystemEvalOptions) (string, error)
 	BuildSystem(buildType BuildType, opts *SystemBuildOptions) (string, error)
 }
 

--- a/internal/configuration/legacy.go
+++ b/internal/configuration/legacy.go
@@ -135,8 +135,8 @@ func (l *LegacyConfiguration) EvalAttribute(attr string) (*string, error) {
 	return &value, nil
 }
 
-func (l *LegacyConfiguration) EvalSystem(s *system.LocalSystem, buildType BuildType, opts *SystemEvalOptions) error {
-	argv := []string{"nix-instantiate", "--eval", l.ConfigPathArg(), "-A", l.BuildAttr(buildType.BuildAttr())}
+func (l *LegacyConfiguration) EvalSystem(s *system.LocalSystem, buildType BuildType, opts *SystemEvalOptions) (string, error) {
+	argv := []string{"nix-instantiate", "--no-gc-warning", l.ConfigPathArg(), "-A", l.BuildAttr(buildType.BuildAttr())}
 
 	if opts.NixOpts != nil {
 		argv = append(argv, opts.NixOpts.ArgsForCommand(nixopts.CmdInstantiate)...)
@@ -144,10 +144,12 @@ func (l *LegacyConfiguration) EvalSystem(s *system.LocalSystem, buildType BuildT
 
 	s.Logger().CmdArray(argv)
 
+	var stdout bytes.Buffer
 	cmd := system.NewCommand(argv[0], argv[1:]...)
+	cmd.Stdout = &stdout
 
 	_, err := s.Run(cmd)
-	return err
+	return strings.TrimSpace(stdout.String()), err
 }
 
 func (l *LegacyConfiguration) buildLocalSystem(s *system.LocalSystem, buildType BuildType, opts *SystemBuildOptions) (string, error) {


### PR DESCRIPTION
The output from `apply --eval-only` with legacy `nixos-cli` is a very long attribute, which is probably not what the user expects. Fix that by copying the `nix-instantiate` arguments from the remote build case, so that only the drv path is outputted. The flake version is similarly adjusted.

Also, adjust the log messages so that they follow the build only format by displaying:
 - a different step message for each build type
 - the drv path upon successful evaluation.