### PR TITLE
fix(docs): fix option eval, add build check

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,3 +39,6 @@ jobs:
 
       - name: Build Nix packages
         run: nix build .#{nixos,nixosLegacy}
+
+      - name: Build docs
+        run: nix develop .# -c make gen-docs

--- a/doc/options.nix
+++ b/doc/options.nix
@@ -1,7 +1,8 @@
-{pkgs ? import <nixpkgs> {}}: let
+let
   self = (import ../nix/flake-compat.nix).outputs;
 
   inherit (self.inputs) nixpkgs;
+  pkgs = nixpkgs.legacyPackages.${builtins.currentSystem};
 
   nixosModules = import "${nixpkgs}/nixos/modules/module-list.nix";
 
@@ -14,11 +15,7 @@ in
         self.nixosModules.nixos-cli
       ];
     specialArgs = {
-      # This missing package is preventing option evaluation from
-      # occurring. This needs to be fixed upstream.
-      pkgs = pkgs.extend (final: prev: {
-        xf86-video-nested = prev.xf86_video_nested;
-      });
+      inherit pkgs;
     };
     excluded = [
       "_module.args"


### PR DESCRIPTION
There have been some problems with flake updates when it comes to generating docs.

This makes the `pkgs` reference when generating the `optnix` option list for the website always use the same `nixpkgs` checkout as the one from the flake. This should avoid evaluation issues and "it works on my machine!" in the future when generating docs.

Also, to prevent build failures of docs from propagating to `main` in the future, building the docs successfully is now a CI requirement for pull requests.