### PR TITLE
fix(module): explicitly set `defaultText` to literal

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -115,6 +115,7 @@ in {
       enable = lib.mkOption {
         type = types.bool;
         default = config.documentation.nixos.enable;
+        defaultText = lib.literalExpression ''config.documentation.nixos.enable'';
         description = "Prebuild JSON cache for `nixos option` command";
       };
 


### PR DESCRIPTION
... as evaluating the default value depends on `config`.

https://nixos.org/manual/nixpkgs/stable/#function-library-lib.options.literalExpression

---

Without this using the nixos module was not possible:
```
> Building NixOS configuration
evaluation warning: The option `programs.nixos-cli.config' defined in `/nix/store/p36y2vxzspcj1lwpyls8nzs8ydbdsrx3-source/hosts/mephistopheles/nix/nixos-cli.nix' has been renamed to `programs.nixos-cli.settings'.
error:
       … while calling the 'head' builtin
         at /nix/store/vc87yvzkz00pppybcmsqvmwa1i3zi2ar-nixpkgs/lib/attrsets.nix:1696:13:
         1695|           if length values == 1 || pred here (elemAt values 1) (head values) then
         1696|             head values
             |             ^
         1697|           else

       … while evaluating the attribute 'value'
         at /nix/store/vc87yvzkz00pppybcmsqvmwa1i3zi2ar-nixpkgs/lib/modules.nix:1118:7:
         1117|     // {
         1118|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |       ^
         1119|       inherit (res.defsFinal') highestPrio;

       … while evaluating the option `system.build.toplevel':

       … while evaluating definitions from `/nix/store/vc87yvzkz00pppybcmsqvmwa1i3zi2ar-nixpkgs/nixos/modules/system/activation/top-level.nix':

       … while evaluating the option `system.systemBuilderArgs':

       … while evaluating definitions from `/nix/store/vc87yvzkz00pppybcmsqvmwa1i3zi2ar-nixpkgs/nixos/modules/system/activation/activatable-system.nix':

       … while evaluating the option `system.activationScripts.etc.text':

       … while evaluating definitions from `/nix/store/vc87yvzkz00pppybcmsqvmwa1i3zi2ar-nixpkgs/nixos/modules/system/etc/etc-activation.nix':

       … while evaluating definitions from `/nix/store/vc87yvzkz00pppybcmsqvmwa1i3zi2ar-nixpkgs/nixos/modules/system/etc/etc.nix':

       … while evaluating the option `environment.etc.dbus-1.source':

       … while evaluating the default value of option `programs.nixos-cli.option-cache.enable`

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'documentation' missing
       at /nix/store/w8833rjnwyyly1506kkdb75g83mxd18h-source/nix/module.nix:117:19:
          116|         type = types.bool;
          117|         default = config.documentation.nixos.enable;
             |                   ^
          118|         description = "Prebuild JSON cache for `nixos option` command";
┏━ 1 Errors:
 ⋮
┃
┃        … while evaluating definitions from `/nix/store/vc87yvzkz00pppybcmsqvmwa1i3zi2ar-nixpkgs/nixos/modules/syst…
┃
┃        … while evaluating definitions from `/nix/store/vc87yvzkz00pppybcmsqvmwa1i3zi2ar-nixpkgs/nixos/modules/syst…
┃
┃        … while evaluating the option `environment.etc.dbus-1.source':
┃
┃        … while evaluating the default value of option `programs.nixos-cli.option-cache.enable`
┃
┃        (stack trace truncated; use '--show-trace' to show the full, detailed trace)
┃
┃        error: attribute 'documentation' missing
┃        at /nix/store/w8833rjnwyyly1506kkdb75g83mxd18h-source/nix/module.nix:117:19:
┃           116|         type = types.bool;
┃           117|         default = config.documentation.nixos.enable;
┃              |                   ^
┃           118|         description = "Prebuild JSON cache for `nixos option` command";
┣━━━
┗━ ∑ ⚠ Exited with 1 errors reported by nix at 17:27:18 after 12s
Error:
   0: Failed to build configuration
   1: Command exited with status Exited(1)

Location:
   src/commands.rs:880
   ```