### PR TITLE
fix(ssh): perform root command elevation test once before password input

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -316,7 +316,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 		// system build type or upgrading channels.
 		if v, ok := buildType.(*configuration.SystemBuild); ok && v.Activate ||
 			!build.Flake() && (opts.UpgradeChannels || opts.UpgradeAllChannels) {
-			if err = utils.ExecAsRoot(cfg.RootCommand); err != nil {
+			if err = utils.ExecAsRoot(cfg.Root.Command); err != nil {
 				log.Errorf("failed to re-exec command as root: %v", err)
 				return err
 			}
@@ -351,6 +351,15 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 		buildHost = host
 	} else {
 		buildHost = localSystem
+	}
+
+	var rootElevator *system.RootElevator
+	if opts.RemoteRoot || (opts.LocalRoot && !effectiveRoot) {
+		rootElevator, err = system.ElevatorFromConfig(&cfg.Root)
+		if err != nil {
+			log.Error(err)
+			return err
+		}
 	}
 
 	var nixConfig configuration.Configuration
@@ -432,8 +441,8 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 
 			if err = upgradeChannels(localSystem, &upgradeChannelsOptions{
 				UpgradeAll:     opts.UpgradeAllChannels,
-				RootCommand:    cfg.RootCommand,
 				UseRootCommand: !effectiveRoot && opts.LocalRoot,
+				RootElevator:   rootElevator,
 			}); err != nil {
 				log.Warnf("failed to update channels: %v", err)
 				log.Warnf("continuing with existing channels")
@@ -625,14 +634,6 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 		}
 	}
 
-	if t, ok := targetHost.(*system.SSHSystem); ok && opts.RemoteRoot {
-		err = t.EnsureRemoteRootPassword(stopCtx, cfg.RootCommand)
-		if err != nil {
-			log.Error(err)
-			return err
-		}
-	}
-
 	specialisation := opts.Specialisation
 	if specialisation == "" {
 		var defaultSpecialisation string
@@ -659,6 +660,16 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 	activationMissingRoot := !effectiveRoot && !opts.LocalRoot && !targetHost.IsRemote()
 	activationUseRoot := !effectiveRoot && opts.LocalRoot && !targetHost.IsRemote() || opts.RemoteRoot && targetHost.IsRemote()
 
+	if rootElevator != nil && activationUseRoot {
+		if rootElevator.PasswordProvider != nil {
+			log.Infof("please enter password for %s", rootElevator.Command)
+			if err = rootElevator.PromptIfNecessary(stopCtx); err != nil {
+				log.Error(err)
+				return err
+			}
+		}
+	}
+
 	// Do not create a generation for dry runs or for
 	// testing generations using the --no-boot option.
 	createGeneration := !opts.Dry && !opts.NoBoot
@@ -677,7 +688,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 			opts.ProfileName,
 			resultLocation,
 			&activation.AddNewNixProfileOptions{
-				RootCommand:    cfg.RootCommand,
+				RootElevator:   rootElevator,
 				UseRootCommand: activationUseRoot,
 			},
 		); err != nil {
@@ -710,8 +721,8 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 				targetHost,
 				opts.ProfileName,
 				previousGenNumber, &activation.SetNixProfileGenerationOptions{
-					RootCommand:    cfg.RootCommand,
 					UseRootCommand: activationUseRoot,
+					RootElevator:   rootElevator,
 				},
 			); err != nil {
 				log.Errorf("failed to rollback system profile: %v", err)
@@ -745,7 +756,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 		InstallBootloader: opts.InstallBootloader,
 		Specialisation:    specialisation,
 		UseRootCommand:    activationUseRoot,
-		RootCommand:       cfg.RootCommand,
+		RootElevator:      rootElevator,
 	})
 	if err != nil {
 		rollbackProfile = true
@@ -760,7 +771,7 @@ const channelDirectory = constants.NixProfileDirectory + "/per-user/root/channel
 
 type upgradeChannelsOptions struct {
 	UpgradeAll     bool
-	RootCommand    string
+	RootElevator   *system.RootElevator
 	UseRootCommand bool
 }
 
@@ -789,8 +800,8 @@ func upgradeChannels(s system.CommandRunner, opts *upgradeChannelsOptions) error
 	s.Logger().CmdArray(argv)
 
 	cmd := system.NewCommand(argv[0], argv[1:]...)
-	if opts.UseRootCommand {
-		cmd.AsRoot(opts.RootCommand)
+	if opts.RootElevator != nil {
+		cmd.AsRoot(opts.RootElevator)
 	}
 	_, err := s.Run(cmd)
 	return err

--- a/cmd/generation/delete/delete.go
+++ b/cmd/generation/delete/delete.go
@@ -132,7 +132,7 @@ func generationDeleteMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts, o
 	s := system.NewLocalSystem(log)
 
 	if os.Geteuid() != 0 {
-		err := utils.ExecAsRoot(cfg.RootCommand)
+		err := utils.ExecAsRoot(cfg.Root.Command)
 		if err != nil {
 			log.Errorf("failed to re-exec command as root: %v", err)
 			return err

--- a/cmd/generation/rollback/rollback.go
+++ b/cmd/generation/rollback/rollback.go
@@ -62,7 +62,7 @@ func generationRollbackMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts,
 	s := system.NewLocalSystem(log)
 
 	if os.Geteuid() != 0 {
-		err := utils.ExecAsRoot(cfg.RootCommand)
+		err := utils.ExecAsRoot(cfg.Root.Command)
 		if err != nil {
 			log.Errorf("failed to re-exec command as root: %v", err)
 			return err

--- a/cmd/generation/switch/switch.go
+++ b/cmd/generation/switch/switch.go
@@ -108,7 +108,7 @@ func generationSwitchMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts, o
 	s := system.NewLocalSystem(log)
 
 	if os.Geteuid() != 0 {
-		err := utils.ExecAsRoot(cfg.RootCommand)
+		err := utils.ExecAsRoot(cfg.Root.Command)
 		if err != nil {
 			log.Errorf("failed to re-exec command as root: %v", err)
 			return err

--- a/internal/activation/activation.go
+++ b/internal/activation/activation.go
@@ -92,8 +92,8 @@ Change the directory to somewhere else (e.g., 'cd $HOME') before trying again.
 Please open an issue if you think this is a mistake.`
 
 type AddNewNixProfileOptions struct {
-	RootCommand    string
 	UseRootCommand bool
+	RootElevator   *system.RootElevator
 }
 
 func AddNewNixProfile(s system.System, profile string, closure string, opts *AddNewNixProfileOptions) error {
@@ -120,7 +120,7 @@ func AddNewNixProfile(s system.System, profile string, closure string, opts *Add
 
 	cmd := system.NewCommand(argv[0], argv[1:]...)
 	if opts.UseRootCommand {
-		cmd.AsRoot(opts.RootCommand)
+		cmd.AsRoot(opts.RootElevator)
 	}
 
 	_, err := s.Run(cmd)
@@ -128,8 +128,8 @@ func AddNewNixProfile(s system.System, profile string, closure string, opts *Add
 }
 
 type SetNixProfileGenerationOptions struct {
-	RootCommand    string
 	UseRootCommand bool
+	RootElevator   *system.RootElevator
 }
 
 func SetNixProfileGeneration(s system.System, profile string, genNumber uint64, opts *SetNixProfileGenerationOptions) error {
@@ -148,7 +148,7 @@ func SetNixProfileGeneration(s system.System, profile string, genNumber uint64, 
 
 	cmd := system.NewCommand(argv[0], argv[1:]...)
 	if opts.UseRootCommand {
-		cmd.AsRoot(opts.RootCommand)
+		cmd.AsRoot(opts.RootElevator)
 	}
 
 	_, err := s.Run(cmd)
@@ -229,7 +229,7 @@ type SwitchToConfigurationOptions struct {
 	InstallBootloader bool
 	Specialisation    string
 	UseRootCommand    bool
-	RootCommand       string
+	RootElevator      *system.RootElevator
 }
 
 func SwitchToConfiguration(s system.CommandRunner, generationLocation string, action SwitchToConfigurationAction, opts *SwitchToConfigurationOptions) error {
@@ -251,7 +251,7 @@ func SwitchToConfiguration(s system.CommandRunner, generationLocation string, ac
 
 	cmd := system.NewCommand(argv[0], argv[1:]...)
 	if opts.UseRootCommand {
-		cmd.AsRoot(opts.RootCommand)
+		cmd.AsRoot(opts.RootElevator)
 	}
 
 	if opts.InstallBootloader {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -17,16 +17,17 @@ type Settings struct {
 	Aliases           map[string][]string  `koanf:"aliases" noset:"true"`
 	Apply             ApplySettings        `koanf:"apply"`
 	AutoRollback      bool                 `koanf:"auto_rollback"`
+	ConfigLocation    string               `koanf:"config_location"`
 	Confirmation      ConfirmationSettings `koanf:"confirmation"`
 	Differ            DifferSettings       `koanf:"differ"`
-	UseColor          bool                 `koanf:"color"`
-	ConfigLocation    string               `koanf:"config_location"`
 	Enter             EnterSettings        `koanf:"enter"`
 	Init              InitSettings         `koanf:"init"`
 	NoConfirm         bool                 `koanf:"no_confirm"`
 	Option            OptionSettings       `koanf:"option"`
-	SSH               SSHSettings          `koanf:"ssh"`
+	Root              RootCommandSettings  `koanf:"root"`
 	RootCommand       string               `koanf:"root_command"`
+	SSH               SSHSettings          `koanf:"ssh"`
+	UseColor          bool                 `koanf:"color"`
 	UseDefaultAliases bool                 `koanf:"use_default_aliases"`
 	UseNvd            bool                 `koanf:"use_nvd"`
 }
@@ -69,6 +70,11 @@ type OptionSettings struct {
 	DebounceTime int64 `koanf:"debounce_time"`
 }
 
+type RootCommandSettings struct {
+	Command        string              `koanf:"command"`
+	PasswordMethod PasswordInputMethod `koanf:"password_method"`
+}
+
 type SSHSettings struct {
 	KnownHostsFiles []string `koanf:"known_hosts_files"`
 	PrivateKeyCmd   []string `koanf:"private_key_cmd"`
@@ -81,6 +87,20 @@ const (
 	ConfirmationPromptDefaultYes ConfirmationPromptBehavior = "default-yes"
 	ConfirmationPromptDefaultNo  ConfirmationPromptBehavior = "default-no"
 )
+
+type PasswordInputMethod string
+
+const (
+	PasswordInputMethodStdin PasswordInputMethod = "stdin"
+	PasswordInputMethodTTY   PasswordInputMethod = "tty"
+	PasswordInputMethodNone  PasswordInputMethod = "none"
+)
+
+var AvailablePasswordInputMethods = map[string]string{
+	string(PasswordInputMethodStdin): "Prompt for the password once and pass it on stdin for all invocations",
+	string(PasswordInputMethodTTY):   "Allocate a TTY and always use interactive input for password",
+	string(PasswordInputMethodNone):  "Fail if command requires authentication",
+}
 
 type DiffTool string
 
@@ -318,9 +338,26 @@ This requires the 'nix-command' experimental feature to be enabled in the Nix co
 			"ssh": {"sh", "-c", "rbw get $NIXOS_CLI_SSH_HOST"},
 		},
 	},
+	"root": {
+		Short: "Settings for root command escalation",
+	},
+	"root.command": {
+		Short: "Command to use to run command as root",
+		Long: "Specifies which command to use for privilege escalation (such as sudo or doas)." +
+			" Password input behavior depends on the `root.password_method` setting.",
+		Example: "doas",
+	},
+	"root.password_method": {
+		Short: "Method to use for passing the invoking user's password",
+		Long: "Specifies the method of password entry for the command." +
+			" The `stdin` method prompts for the password once, and passes it on the process's standard input with a trailing newline for all invoking processes." +
+			" The `tty` method will allocate a TTY if necessary (i.e. when running over SSH), and almost always requires interactive input." +
+			" The `none` method assumes that no password is required (i.e. when a sudo user has NOPASSWD set), and will fail otherwise.",
+	},
 	"root_command": {
-		Short: "Command to use to promote process to root",
-		Long:  "Specifies which command to use for privilege escalation (e.g., sudo or doas).",
+		Short:      "Command to use to promote process to root",
+		Long:       "Specifies which command to use for privilege escalation (such as sudo or doas)",
+		Deprecated: "Use the settings defined under the `root` key instead.",
 	},
 	"use_default_aliases": {
 		Short: "Enables default list of aliases",
@@ -350,12 +387,15 @@ func NewSettings() *Settings {
 		Enter: EnterSettings{
 			MountResolvConf: true,
 		},
-		Init:        InitSettings{},
-		RootCommand: "sudo",
+		Init: InitSettings{},
 		Option: OptionSettings{
 			MinScore:     1,
 			Prettify:     true,
 			DebounceTime: 25,
+		},
+		Root: RootCommandSettings{
+			Command:        "sudo",
+			PasswordMethod: PasswordInputMethodStdin,
 		},
 		SSH:               SSHSettings{},
 		UseDefaultAliases: true,
@@ -451,6 +491,20 @@ func (cfg *Settings) Validate() SettingsErrors {
 	default:
 		errs = append(errs, SettingsError{Field: "differ.tool", Message: fmt.Sprintf("invalid value '%s' specified", cfg.Differ.Tool)})
 		cfg.Differ.Tool = DifferNix
+	}
+
+	if cfg.RootCommand != "" {
+		errs = append(errs, DeprecatedSettingError{
+			Field:       "root_command",
+			Alternative: "use the settings defined under the `root` key instead",
+		})
+		cfg.Root.Command = cfg.RootCommand
+		// Make sure that known elevation tools don't suddenly break
+		// when still in the backwards compat phase.
+		if cfg.Root.Command == "doas" || cfg.Root.Command == "run0" {
+			errs = append(errs, fmt.Errorf("since %s is being used, make sure to set `root.password_method` to 'tty' as well", cfg.Root.Command))
+			cfg.Root.PasswordMethod = PasswordInputMethodTTY
+		}
 	}
 
 	if len(errs) > 0 {

--- a/internal/system/elevator.go
+++ b/internal/system/elevator.go
@@ -1,0 +1,107 @@
+package system
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/nix-community/nixos-cli/internal/settings"
+	"github.com/nix-community/nixos-cli/internal/utils"
+)
+
+type RootElevator struct {
+	Command          string
+	Flags            []string
+	Method           settings.PasswordInputMethod
+	PasswordProvider PasswordProvider
+}
+
+type PasswordProvider interface {
+	GetPassword() (string, error)
+	PromptForPassword(ctx context.Context, prompt string) (string, error)
+}
+
+func ElevatorFromConfig(cfg *settings.RootCommandSettings) (*RootElevator, error) {
+	var flags []string
+	var provider PasswordProvider
+
+	switch cfg.Command {
+	case "sudo":
+		switch cfg.PasswordMethod {
+		case settings.PasswordInputMethodStdin:
+			flags = append(flags, "-S", "-p", "")
+		case settings.PasswordInputMethodNone:
+			flags = append(flags, "-n")
+		}
+	case "doas":
+		switch cfg.PasswordMethod {
+		case settings.PasswordInputMethodStdin:
+			return nil, errors.New("doas does not support password input through stdin")
+		case settings.PasswordInputMethodNone:
+			flags = append(flags, "-n")
+		}
+	case "run0":
+		switch cfg.PasswordMethod {
+		case settings.PasswordInputMethodNone, settings.PasswordInputMethodStdin:
+			return nil, errors.New("run0 only supports the tty method for password input")
+		}
+	default:
+		flags = nil
+	}
+
+	if cfg.PasswordMethod == settings.PasswordInputMethodStdin {
+		provider = &CachedPasswordProvider{}
+	}
+
+	return &RootElevator{
+		Command:          cfg.Command,
+		Flags:            flags,
+		Method:           cfg.PasswordMethod,
+		PasswordProvider: provider,
+	}, nil
+}
+
+func (e *RootElevator) PromptIfNecessary(ctx context.Context) error {
+	if e.PasswordProvider == nil {
+		return nil
+	}
+
+	var prompt string
+
+	if currentUser, _ := utils.GetUsername(); currentUser != "" {
+		prompt = fmt.Sprintf("[%s] password for %s: ", e.Command, currentUser)
+	} else {
+		prompt = fmt.Sprintf("[%s] enter password: ", e.Command)
+	}
+
+	_, err := e.PasswordProvider.PromptForPassword(ctx, prompt)
+	return err
+}
+
+type CachedPasswordProvider struct {
+	password string
+	set      bool
+}
+
+func (p *CachedPasswordProvider) GetPassword() (string, error) {
+	if p.set {
+		return p.password, nil
+	}
+
+	return "", errors.New("root elevation password not set")
+}
+
+func (p *CachedPasswordProvider) PromptForPassword(ctx context.Context, prompt string) (string, error) {
+	if p.set {
+		return p.password, nil
+	}
+
+	password, err := utils.PromptForPassword(ctx, prompt)
+	if err != nil {
+		return "", err
+	}
+
+	p.password = string(password)
+	p.set = true
+	return p.password, nil
+}

--- a/internal/system/local.go
+++ b/internal/system/local.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"syscall"
 
 	"github.com/nix-community/nixos-cli/internal/logger"
+	"github.com/nix-community/nixos-cli/internal/settings"
 )
 
 type LocalSystem struct {
@@ -33,7 +35,7 @@ func (l *LocalSystem) Run(cmd *Command) (int, error) {
 
 	var err error
 
-	if cmd.RootElevationCmd != "" {
+	if cmd.rootElevator != nil {
 		// If environment variables are specified,
 		// use the shell wrapper to set them inline
 		// to bypass root elevation environment
@@ -61,10 +63,37 @@ func (l *LocalSystem) Run(cmd *Command) (int, error) {
 	command.Stdin = cmd.Stdin
 	command.Env = os.Environ()
 
-	// If RootElevationCmd is set, then these variables are
-	// handled by the wrapper. Otherwise, set them directly
-	// for the process.
-	if cmd.RootElevationCmd == "" {
+	if elevator := cmd.rootElevator; elevator != nil {
+		switch elevator.Method {
+		case settings.PasswordInputMethodStdin:
+			if elevator.PasswordProvider == nil {
+				return 0, fmt.Errorf("password provider is required for stdin password input method")
+			}
+			// Processes will likely never expect stdin to be set for SSH
+			// if they are running as root, since this seems to be a
+			// fairly uncommon scenario to need to pass things through
+			// stdin while simultaneously needing root, and we will likely
+			// never need something like that here.
+			//
+			// As such, we're replacing the entire stdin with this password.
+			pwStr, pwErr := elevator.PasswordProvider.GetPassword()
+			if pwErr != nil {
+				return 0, pwErr
+			}
+			pw := append([]byte(pwStr), '\n')
+			command.Stdin = bytes.NewReader(pw)
+		case settings.PasswordInputMethodTTY:
+			// Do nothing; if the input is not a terminal, then
+			// it will fail on its own.
+		case settings.PasswordInputMethodNone:
+			command.Stdin = nil
+		default:
+			return 0, fmt.Errorf("unsupported password input method: %v", elevator.Method)
+		}
+	} else {
+		// If the root elevator is set, then these variables are
+		// handled by the wrapper. Otherwise, set them directly
+		// for the process.
 		for key, value := range cmd.Env {
 			command.Env = append(command.Env, key+"="+value)
 		}

--- a/internal/system/runner.go
+++ b/internal/system/runner.go
@@ -3,10 +3,8 @@ package system
 import (
 	"errors"
 	"io"
-	"maps"
 	"os"
 	"regexp"
-	"slices"
 	"sort"
 	"strings"
 
@@ -28,8 +26,7 @@ type Command struct {
 	Stderr io.Writer
 	Env    map[string]string
 
-	RootElevationCmd      string
-	RootElevationCmdFlags []string
+	rootElevator *RootElevator
 }
 
 func NewCommand(name string, args ...string) *Command {
@@ -51,31 +48,9 @@ func (c *Command) SetEnv(key string, value string) {
 	c.Env[key] = value
 }
 
-func (c *Command) AsRoot(rootCmd string, rootCmdFlags ...string) *Command {
-	c.RootElevationCmd = rootCmd
-	c.RootElevationCmdFlags = rootCmdFlags
+func (c *Command) AsRoot(elevator *RootElevator) *Command {
+	c.rootElevator = elevator
 	return c
-}
-
-func (c *Command) Clone() *Command {
-	args := slices.Clone(c.Args)
-
-	env := make(map[string]string, len(c.Env))
-	maps.Copy(env, c.Env)
-
-	rootElevationCmdFlags := slices.Clone(c.RootElevationCmdFlags)
-
-	return &Command{
-		Name:   c.Name,
-		Args:   args,
-		Stdin:  c.Stdin,
-		Stdout: c.Stdout,
-		Stderr: c.Stderr,
-		Env:    env,
-
-		RootElevationCmd:      c.RootElevationCmd,
-		RootElevationCmdFlags: rootElevationCmdFlags,
-	}
 }
 
 var envVarNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
@@ -94,18 +69,20 @@ func (c *Command) BuildShellWrapper() ([]string, error) {
 		return nil, errors.New("NUL (0x00) bytes are not allowed in env values or args")
 	}
 
-	if strings.IndexByte(c.RootElevationCmd, 0) != -1 {
-		return nil, errors.New("NUL (0x00) bytes are not allowed in env values or args")
-	}
-
 	for _, a := range c.Args {
 		if strings.IndexByte(a, 0) != -1 {
 			return nil, errors.New("NUL (0x00) bytes are not allowed in env values or args")
 		}
 	}
 
-	for _, a := range c.RootElevationCmdFlags {
-		if strings.IndexByte(a, 0) != -1 {
+	if elevator := c.rootElevator; elevator != nil {
+		for _, a := range elevator.Flags {
+			if strings.IndexByte(a, 0) != -1 {
+				return nil, errors.New("NUL (0x00) bytes are not allowed in env values or args")
+			}
+		}
+
+		if strings.IndexByte(elevator.Command, 0) != -1 {
 			return nil, errors.New("NUL (0x00) bytes are not allowed in env values or args")
 		}
 	}
@@ -153,11 +130,11 @@ func (c *Command) BuildShellWrapper() ([]string, error) {
 	wrappedCmdScript := b.String()
 
 	var argv []string
-	if c.RootElevationCmd != "" {
+	if elevator := c.rootElevator; elevator != nil {
 		// Root elevation commands/flags must go BEFORE the `sh` invocation.
 		// This will ensure that the environment is preserved across the
 		// elevation boundary.
-		argv = append([]string{c.RootElevationCmd}, c.RootElevationCmdFlags...)
+		argv = append([]string{elevator.Command}, elevator.Flags...)
 	}
 	argv = append(argv, "sh", "-c", wrappedCmdScript)
 
@@ -173,9 +150,9 @@ func (c *Command) BuildShellWrapper() ([]string, error) {
 func (c *Command) BuildArgs() []string {
 	var argv []string
 
-	if c.RootElevationCmd != "" {
-		argv = append(argv, c.RootElevationCmd)
-		argv = append(argv, c.RootElevationCmdFlags...)
+	if elevator := c.rootElevator; elevator != nil {
+		argv = append(argv, elevator.Command)
+		argv = append(argv, elevator.Flags...)
 	}
 
 	argv = append(argv, c.Name)

--- a/internal/system/runner_test.go
+++ b/internal/system/runner_test.go
@@ -3,6 +3,8 @@ package system
 import (
 	"strings"
 	"testing"
+
+	"github.com/nix-community/nixos-cli/internal/settings"
 )
 
 func TestBuildShellWrapper_NoEnv_NoRoot(t *testing.T) {
@@ -94,8 +96,14 @@ func TestBuildShellWrapper_NulInArgs(t *testing.T) {
 }
 
 func TestBuildShellWrapper_WithRootElevation(t *testing.T) {
+	elevator := &RootElevator{
+		Command: "sudo",
+		Flags:   []string{"-n"},
+		Method:  settings.PasswordInputMethodNone,
+	}
+
 	cmd := NewCommand("id")
-	cmd.AsRoot("sudo", "-n")
+	cmd.AsRoot(elevator)
 
 	argv, err := cmd.BuildShellWrapper()
 	if err != nil {

--- a/internal/system/ssh.go
+++ b/internal/system/ssh.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -33,8 +32,6 @@ type SSHSystem struct {
 
 	client *ssh.Client
 	sftp   *sftp.Client
-
-	rootPassword []byte
 
 	logger logger.Logger
 }
@@ -79,14 +76,12 @@ func NewSSHConfig(ctx context.Context, host string, log logger.Logger, options S
 	var port int
 
 	if hostInfo.User == "" {
-		var current *user.User
-		if current, err = user.Current(); err == nil {
-			username = current.Username
-		} else if current := os.Getenv("USER"); current != "" {
-			username = current
-		} else {
-			return nil, fmt.Errorf("failed to determine current user")
+		var currentUser string
+		currentUser, err = utils.GetUsername()
+		if err != nil {
+			return nil, err
 		}
+		username = currentUser
 	} else {
 		username = hostInfo.User
 	}
@@ -158,7 +153,7 @@ func NewSSHConfig(ctx context.Context, host string, log logger.Logger, options S
 		}
 
 		var bytePassword []byte
-		bytePassword, err = promptForPassword(ctx, username, address)
+		bytePassword, err = utils.PromptForPassword(ctx, fmt.Sprintf("Password for %s@%s:", username, address))
 		if err != nil {
 			return "", err
 		}
@@ -236,8 +231,6 @@ func NewSSHSystem(cfg *SSHConfig, log logger.Logger) (*SSHSystem, error) {
 		client: client,
 		sftp:   sftpClient,
 
-		rootPassword: cfg.password,
-
 		logger: log,
 	}, nil
 }
@@ -260,41 +253,6 @@ func dialClient(cfg *SSHConfig) (*ssh.Client, *sftp.Client, error) {
 	}
 
 	return client, sftpClient, nil
-}
-
-// Ensure that a password exists for any root elevation command
-// if necessary.
-//
-// This makes sure that any root elevation can be invoked properly
-// on the remote system, even if a password wasn't specified before.
-func (s *SSHSystem) EnsureRemoteRootPassword(ctx context.Context, rootCmd string) error {
-	// If the password already exists, presumably we already have sudo
-	// permissions and don't need to check. If the logged-in user doesn't,
-	// then the first command that requires sudo will say as much and exit,
-	// so no need to verify it explicitly here.
-	if s.rootPassword != nil {
-		return nil
-	}
-
-	if s.cfg.password != nil {
-		s.rootPassword = s.cfg.password
-		return nil
-	}
-
-	s.Logger().Info("please input password to run commands as root")
-
-	bytePassword, err := promptForPassword(ctx, s.cfg.User, s.cfg.Address)
-	if err != nil {
-		return err
-	}
-
-	s.rootPassword = bytePassword
-
-	if err = s.testRemoteRoot(rootCmd); err != nil {
-		return fmt.Errorf("failed to verify %s password: %s", rootCmd, err)
-	}
-
-	return nil
 }
 
 func (s *SSHSystem) Reconnect() error {
@@ -328,17 +286,8 @@ func (s *SSHSystem) Clone() (*SSHSystem, error) {
 		client: client,
 		sftp:   sftpClient,
 
-		rootPassword: s.rootPassword,
-
 		logger: s.logger,
 	}, nil
-}
-
-func (s *SSHSystem) testRemoteRoot(rootCmd string) error {
-	cmd := NewCommand("true").AsRoot(rootCmd)
-
-	_, err := s.Run(cmd)
-	return err
 }
 
 func runPrivateKeyCmd(s *LocalSystem, host string, username string, privateKeyCmd []string) (any, error) {
@@ -364,47 +313,6 @@ func runPrivateKeyCmd(s *LocalSystem, host string, username string, privateKeyCm
 	return signer, nil
 }
 
-// Prompt for a password from stdin.
-//
-// This operation can be cancelled using the provided context.
-func promptForPassword(ctx context.Context, username string, address string) ([]byte, error) {
-	fd := int(os.Stdin.Fd())
-	if !term.IsTerminal(fd) {
-		return nil, fmt.Errorf("cannot prompt for password: stdin is not a terminal")
-	}
-
-	oldState, err := term.GetState(fd)
-	if err != nil {
-		return nil, err
-	}
-
-	fmt.Fprintf(os.Stderr, "Password for %s@%s: ", username, address)
-	_ = os.Stdin.Sync()
-
-	type result struct {
-		pw  []byte
-		err error
-	}
-
-	ch := make(chan result, 1)
-
-	go func() {
-		pw, readErr := term.ReadPassword(fd)
-		ch <- result{pw, readErr}
-	}()
-
-	select {
-	case <-ctx.Done():
-		_ = term.Restore(fd, oldState)
-		fmt.Fprintln(os.Stderr)
-		return nil, ctx.Err()
-
-	case res := <-ch:
-		fmt.Fprintln(os.Stderr)
-		return res.pw, res.err
-	}
-}
-
 // This mimics the automatic addition of known_hosts entries
 // to the known_hosts file that OpenSSH performs.
 //
@@ -418,8 +326,7 @@ func addKeyToKnownHostsCallback(log logger.Logger, origCallback ssh.HostKeyCallb
 			return nil
 		}
 
-		var keyErr *knownhosts.KeyError
-		if errors.As(err, &keyErr) {
+		if keyErr, ok := errors.AsType[*knownhosts.KeyError](err); ok {
 			// Only allow adding the key like OpenSSH does if the
 			// stdin terminal can accept input.
 			if !term.IsTerminal(int(os.Stdin.Fd())) {
@@ -500,25 +407,28 @@ func (s *SSHSystem) Run(cmd *Command) (int, error) {
 		}
 	}()
 
-	if cmd.RootElevationCmd != "" {
-		// Pass `sudo` passwords from `stdin` if they are present.
-		// This requires the `-S` flag.
-		//
-		// Processes will likely never expect stdin to be set for SSH
-		// if they are running as root, since this seems to be a
-		// fairly uncommon scenario to need to pass things through
-		// stdin while simultaneously needing root, and we will likely
-		// never need something like that here.
-		//
-		// As such, we're replacing the entire stdin with this password.
-		if cmd.RootElevationCmd == "sudo" && s.rootPassword != nil {
-			// Make a copy of the command struct to add the root elevation flags to
-			cmd = cmd.Clone()
-			cmd.RootElevationCmdFlags = append(cmd.RootElevationCmdFlags, "-S", "-p", "")
-			pw := append([]byte{}, s.rootPassword...)
-			pw = append(pw, '\n')
+	if elevator := cmd.rootElevator; elevator != nil {
+		switch elevator.Method {
+		case settings.PasswordInputMethodStdin:
+			if elevator.PasswordProvider == nil {
+				return 0, fmt.Errorf("password provider is required for stdin password input method")
+			}
+			// Processes will likely never expect stdin to be set for SSH
+			// if they are running as root, since this seems to be a
+			// fairly uncommon scenario to need to pass things through
+			// stdin while simultaneously needing root, and we will likely
+			// never need something like that here.
+			//
+			// As such, we're replacing the entire stdin with this password.
+			pwStr, pwErr := elevator.PasswordProvider.GetPassword()
+			if pwErr != nil {
+				return 0, pwErr
+			}
+			pw := append([]byte(pwStr), '\n')
+
 			session.Stdin = bytes.NewReader(pw)
-		} else if isTerminal(cmd.Stdin) {
+
+		case settings.PasswordInputMethodTTY:
 			session.Stdin = cmd.Stdin
 			// sudo and other root-escalating commands need a PTY if running
 			// in interactive mode.
@@ -533,10 +443,7 @@ func (s *SSHSystem) Run(cmd *Command) (int, error) {
 			// The preferred way to avoid interactive input from root-escalating
 			// commands is to have a user that can run such a command with a no-password
 			// policy such as sudo's NOPASSWD directive, and to deploy using that.
-			//
-			// FIXME: Entering passwords interactively with `sudo` and a PTY
-			// seems to have a bug where the first attempt is wrong due to
-			// the PTY discarding the first inputted byte.
+
 			var restoreLocal func()
 			restoreLocal, err = requestRootPasswordPTY(session, cmd.Stdin)
 			if err != nil {
@@ -544,6 +451,25 @@ func (s *SSHSystem) Run(cmd *Command) (int, error) {
 			} else {
 				defer restoreLocal()
 			}
+		case settings.PasswordInputMethodNone:
+			session.Stdin = nil
+		default:
+			return 0, fmt.Errorf("unsupported password input method: %v", elevator.Method)
+		}
+	} else {
+		session.Stdin = cmd.Stdin
+	}
+
+	// HACK: A stupid bug.
+	// https://github.com/golang/go/issues/41390
+	// And a stupid workaround to show for it.
+	if session.Stdin == os.Stdin {
+		dupStdin, openErr := os.OpenFile("/dev/stdin", os.O_RDONLY, 0)
+		if openErr != nil {
+			log.Warnf("failed to open stdin: %v", openErr)
+		} else {
+			defer dupStdin.Close()
+			session.Stdin = dupStdin
 		}
 	}
 
@@ -631,8 +557,19 @@ func requestRootPasswordPTY(session *ssh.Session, stdin io.Reader) (func(), erro
 		return nil, errors.New("stdin is not a file")
 	}
 
+	fd := int(file.Fd())
+	oldState, err := term.MakeRaw(fd)
+	if err != nil {
+		return nil, err
+	}
+
+	restoreTerminalState := func() {
+		_ = term.Restore(fd, oldState)
+	}
+
 	w, h, err := term.GetSize(int(file.Fd()))
 	if err != nil {
+		restoreTerminalState()
 		return nil, fmt.Errorf("failed to get terminal size: %w", err)
 	}
 
@@ -648,18 +585,11 @@ func requestRootPasswordPTY(session *ssh.Session, stdin io.Reader) (func(), erro
 	}
 
 	if err = session.RequestPty(termType, h, w, modes); err != nil {
+		restoreTerminalState()
 		return nil, fmt.Errorf("failed to allocate pty for process: %w", err)
 	}
 
-	fd := int(file.Fd())
-	oldState, err := term.MakeRaw(fd)
-	if err != nil {
-		return nil, err
-	}
-
-	return func() {
-		_ = term.Restore(fd, oldState)
-	}, nil
+	return restoreTerminalState, nil
 }
 
 func (s *SSHSystem) IsNixOS() bool {
@@ -714,14 +644,4 @@ func (s *SSHSystem) HasCommand(name string) bool {
 func (s *SSHSystem) Close() {
 	_ = s.sftp.Close()
 	_ = s.client.Close()
-}
-
-func isTerminal(r io.Reader) bool {
-	file, ok := r.(*os.File)
-	if !ok {
-		return false
-	}
-
-	fd := file.Fd()
-	return term.IsTerminal(int(fd))
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,13 +1,17 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"syscall"
+
+	"golang.org/x/term"
 )
 
 // Re-exec the current process as root with the same arguments.
@@ -130,4 +134,55 @@ func ResolveDirectory(input string) (string, error) {
 	}
 
 	return absolutePath, nil
+}
+
+// Prompt for a password from stdin.
+//
+// This operation can be cancelled using the provided context.
+func PromptForPassword(ctx context.Context, prompt string) ([]byte, error) {
+	fd := int(os.Stdin.Fd())
+	if !term.IsTerminal(fd) {
+		return nil, fmt.Errorf("cannot prompt for password: stdin is not a terminal")
+	}
+
+	oldState, err := term.GetState(fd)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Fprintf(os.Stderr, "%s", prompt)
+
+	type result struct {
+		pw  []byte
+		err error
+	}
+
+	ch := make(chan result, 1)
+
+	go func() {
+		pw, readErr := term.ReadPassword(fd)
+		ch <- result{pw, readErr}
+	}()
+
+	select {
+	case <-ctx.Done():
+		_ = term.Restore(fd, oldState)
+		fmt.Fprintln(os.Stderr)
+		return nil, ctx.Err()
+
+	case res := <-ch:
+		fmt.Fprintln(os.Stderr)
+		return res.pw, res.err
+	}
+}
+
+// Get the current user's username.
+func GetUsername() (string, error) {
+	if current, err := user.Current(); err == nil {
+		return current.Username, nil
+	} else if u := os.Getenv("USER"); u != "" {
+		return u, nil
+	} else {
+		return "", fmt.Errorf("failed to determine current user")
+	}
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -136,13 +136,33 @@ func ResolveDirectory(input string) (string, error) {
 	return absolutePath, nil
 }
 
-// Prompt for a password from stdin.
+// Prompt for a password from /dev/tty or stdin.
 //
-// This operation can be cancelled using the provided context.
+// This operation can be cancelled using the provided context,
+// but any errors returned from here MAY have the potential
+// to keep consuming stdin until another character is typed
+// if /dev/tty or a duplicate instance of stdin cannot be
+// opened, so any errors here will result in potentially
+// undefined behavior for stdin input.
 func PromptForPassword(ctx context.Context, prompt string) ([]byte, error) {
-	fd := int(os.Stdin.Fd())
-	if !term.IsTerminal(fd) {
-		return nil, fmt.Errorf("cannot prompt for password: stdin is not a terminal")
+	var fd int
+
+	if tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0); err == nil {
+		defer tty.Close()
+		fd = int(tty.Fd())
+	} else if term.IsTerminal(int(os.Stdin.Fd())) {
+		dupStdin, openErr := os.OpenFile("/dev/stdin", os.O_RDONLY, 0)
+		if openErr == nil {
+			defer dupStdin.Close()
+			fd = int(dupStdin.Fd())
+		} else {
+			// NOTE: falling back to stdin will make context
+			// cancellation behavior a bit unclear, as mentioned
+			// in the doc comment.
+			fd = int(os.Stdin.Fd())
+		}
+	} else {
+		return nil, fmt.Errorf("standard input is not a terminal, and /dev/tty is not available: %v", err)
 	}
 
 	oldState, err := term.GetState(fd)


### PR DESCRIPTION
There is a litany of bugs that exist with current root elevation mechanisms.

- Commands that require input (i.e. `sudo` invocations) often dispose of the first character; this only applies to the second command ran with a single SSH client and subsequent ones, and makes password input for them very messy.
- When a user was configured to have passwordless `sudo`/`doas` elevation, attempting to activate with that user in `nixos apply --target-host` was broken since it would always ask for a password when `EnsureRemoteRemotePassword` was called, thus making it non-interactive.

This PR solves issues like these by making the root elevation mechanism much more consistent, and by exposing more behavior to the user through settings.

Now, every root command can either choose to:

- Take the password as input once, and then pass it using `stdin` along with a newline. The command must support it; i.e. `sudo` can take passwords on `stdin`, and this is the default settings.
- Force using a TTY whenever possible; this only really applies to running commands over SSH, and leaves local root elevation virtually unchanged.
- Do not allow any input, and immediately fail if interactive input is requested. This only works if a user is configured with `NOPASSWD` in `sudo`, or `nopass` in doas, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured root privilege escalation configuration with `root.command` and `root.password_method` settings
  * Introduced support for multiple password input methods: stdin, TTY, and none

* **Bug Fixes**
  * Improved password prompting behavior and error handling for root elevation operations

* **Chores**
  * Deprecated legacy `root_command` setting in favor of new nested `root` configuration structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->