### PR TITLE
fix(settings): resolve bugs with completions/validation

### DIFF
--- a/internal/settings/completion.go
+++ b/internal/settings/completion.go
@@ -212,6 +212,9 @@ func completeConfirmationBehaviorKey(key, candidate string) ([]string, cobra.She
 var completionValueFuncs = map[string]CompletionValueFunc{
 	"confirmation.empty":   completeConfirmationBehaviorKey,
 	"confirmation.invalid": completeConfirmationBehaviorKey,
+	"root.password_method": func(key, candidate string) ([]string, cobra.ShellCompDirective) {
+		return stringCompletionFunc(key, candidate, AvailablePasswordInputMethods)
+	},
 	"differ.tool": func(key, candidate string) ([]string, cobra.ShellCompDirective) {
 		return stringCompletionFunc(key, candidate, AvailableDiffToolOptions)
 	},

--- a/internal/settings/completion.go
+++ b/internal/settings/completion.go
@@ -57,7 +57,7 @@ func findFieldCompletions(value any, prefix string) ([]fieldCompleteResult, bool
 		}
 	}
 
-	if current.Kind() == reflect.Ptr {
+	if current.Kind() == reflect.Pointer {
 		if current.IsNil() {
 			current.Set(reflect.New(current.Type().Elem()))
 		}
@@ -142,13 +142,10 @@ func bestDescriptionFor(name string) string {
 }
 
 func CompleteConfigFlag(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	splitIndex := strings.Index(toComplete, "=")
-	if splitIndex == -1 {
+	key, candidate, ok := strings.Cut(toComplete, "=")
+	if !ok {
 		return completeKeys(toComplete)
 	}
-
-	key := toComplete[0:splitIndex]
-	candidate := toComplete[splitIndex+1:]
 
 	return completeValues(key, candidate)
 }
@@ -244,7 +241,7 @@ func findField(root any, key string) *reflect.Value {
 	parts := strings.Split(key, ".")
 	current := reflect.ValueOf(root)
 
-	if current.Kind() == reflect.Ptr {
+	if current.Kind() == reflect.Pointer {
 		current = current.Elem()
 	}
 
@@ -258,7 +255,7 @@ func findField(root any, key string) *reflect.Value {
 			field := current.Type().Field(i)
 			if field.Tag.Get("koanf") == part {
 				current = current.Field(i)
-				if current.Kind() == reflect.Ptr {
+				if current.Kind() == reflect.Pointer {
 					if current.IsNil() {
 						return nil
 					}

--- a/internal/settings/completion.go
+++ b/internal/settings/completion.go
@@ -236,6 +236,10 @@ func completeValues(key string, value string) ([]string, cobra.ShellCompDirectiv
 
 func isBoolField(root any, key string) bool {
 	field := findField(root, key)
+	if field == nil {
+		return false
+	}
+
 	kind := field.Kind()
 	return kind == reflect.Bool
 }

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"encoding"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -561,6 +562,15 @@ func (cfg *Settings) SetValue(key string, value string) error {
 		if i == len(fields)-1 {
 			if !current.CanSet() {
 				return SettingsError{Field: field, Message: "cannot change value of this setting dynamically"}
+			}
+
+			if current.CanAddr() {
+				if unmarshaler, ok := current.Addr().Interface().(encoding.TextUnmarshaler); ok {
+					if err := unmarshaler.UnmarshalText([]byte(value)); err != nil {
+						return err
+					}
+					return nil
+				}
 			}
 
 			switch current.Kind() {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -97,6 +97,17 @@ const (
 	PasswordInputMethodNone  PasswordInputMethod = "none"
 )
 
+func (d *PasswordInputMethod) UnmarshalText(text []byte) error {
+	v := PasswordInputMethod(text)
+	switch v {
+	case PasswordInputMethodStdin, PasswordInputMethodTTY, PasswordInputMethodNone:
+		*d = v
+		return nil
+	default:
+		return fmt.Errorf("invalid value for password input method '%s'", text)
+	}
+}
+
 var AvailablePasswordInputMethods = map[string]string{
 	string(PasswordInputMethodStdin): "Prompt for the password once and pass it on stdin for all invocations",
 	string(PasswordInputMethodTTY):   "Allocate a TTY and always use interactive input for password",


### PR DESCRIPTION
Some bugs existed with the settings, including:

- Missing completions/validations
- `--config` not validating passed string enum values
- Panics in certain situations with invalid keys, which screws up completion output

This PR finds those and resolves them, and also uses `UnmarshalText()` when needed to ensure strong validation of enum keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error handling for password input method configuration options.
  * Enhanced configuration completion detection for boolean fields.
  * Refined configuration flag parsing for more robust input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->