### PR TITLE
feat(settings): add SSH host key checking option

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -253,6 +253,16 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 		}
 	}()
 
+	needsConfirmation := !opts.AlwaysConfirm && !cfg.Confirmation.Always
+
+	// If no confirmation is needed, then manually override the host
+	// key verification type so that host keys can always be added to
+	// known_hosts.
+	hostKeyVerification := cfg.SSH.HostKeyVerification
+	if hostKeyVerification == settings.HostKeyVerificationAsk && !needsConfirmation {
+		hostKeyVerification = settings.HostKeyVerificationAcceptNew
+	}
+
 	var targetHost system.System
 
 	if opts.TargetHost != "" {
@@ -261,7 +271,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 		var sshCfg *system.SSHConfig
 		sshCfg, err = system.NewSSHConfig(stopCtx, opts.TargetHost, log, system.SSHConfigOptions{
 			AgentManager:        sshAgent,
-			HostKeyVerification: cfg.SSH.HostKeyVerification,
+			HostKeyVerification: hostKeyVerification,
 			KnownHostsFiles:     cfg.SSH.KnownHostsFiles,
 			PrivateKeyCmd:       cfg.SSH.PrivateKeyCmd,
 		})
@@ -335,7 +345,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 		var sshCfg *system.SSHConfig
 		sshCfg, err = system.NewSSHConfig(stopCtx, opts.BuildHost, log, system.SSHConfigOptions{
 			AgentManager:        sshAgent,
-			HostKeyVerification: cfg.SSH.HostKeyVerification,
+			HostKeyVerification: hostKeyVerification,
 			KnownHostsFiles:     cfg.SSH.KnownHostsFiles,
 			PrivateKeyCmd:       cfg.SSH.PrivateKeyCmd,
 		})

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -260,9 +260,10 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 
 		var sshCfg *system.SSHConfig
 		sshCfg, err = system.NewSSHConfig(stopCtx, opts.TargetHost, log, system.SSHConfigOptions{
-			AgentManager:    sshAgent,
-			KnownHostsFiles: cfg.SSH.KnownHostsFiles,
-			PrivateKeyCmd:   cfg.SSH.PrivateKeyCmd,
+			AgentManager:        sshAgent,
+			HostKeyVerification: cfg.SSH.HostKeyVerification,
+			KnownHostsFiles:     cfg.SSH.KnownHostsFiles,
+			PrivateKeyCmd:       cfg.SSH.PrivateKeyCmd,
 		})
 		if err != nil {
 			log.Errorf("%v", err)
@@ -333,9 +334,10 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 
 		var sshCfg *system.SSHConfig
 		sshCfg, err = system.NewSSHConfig(stopCtx, opts.BuildHost, log, system.SSHConfigOptions{
-			AgentManager:    sshAgent,
-			KnownHostsFiles: cfg.SSH.KnownHostsFiles,
-			PrivateKeyCmd:   cfg.SSH.PrivateKeyCmd,
+			AgentManager:        sshAgent,
+			HostKeyVerification: cfg.SSH.HostKeyVerification,
+			KnownHostsFiles:     cfg.SSH.KnownHostsFiles,
+			PrivateKeyCmd:       cfg.SSH.PrivateKeyCmd,
 		})
 		if err != nil {
 			log.Errorf("%v", err)

--- a/internal/settings/completion.go
+++ b/internal/settings/completion.go
@@ -212,11 +212,14 @@ func completeConfirmationBehaviorKey(key, candidate string) ([]string, cobra.She
 var completionValueFuncs = map[string]CompletionValueFunc{
 	"confirmation.empty":   completeConfirmationBehaviorKey,
 	"confirmation.invalid": completeConfirmationBehaviorKey,
+	"differ.tool": func(key, candidate string) ([]string, cobra.ShellCompDirective) {
+		return stringCompletionFunc(key, candidate, AvailableDiffToolOptions)
+	},
 	"root.password_method": func(key, candidate string) ([]string, cobra.ShellCompDirective) {
 		return stringCompletionFunc(key, candidate, AvailablePasswordInputMethods)
 	},
-	"differ.tool": func(key, candidate string) ([]string, cobra.ShellCompDirective) {
-		return stringCompletionFunc(key, candidate, AvailableDiffToolOptions)
+	"ssh.host_key_verification": func(key, candidate string) ([]string, cobra.ShellCompDirective) {
+		return stringCompletionFunc(key, candidate, AvailableHostKeyVerificationOptions)
 	},
 }
 

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -374,6 +374,7 @@ This requires the 'nix-command' experimental feature to be enabled in the Nix co
 		Short: "Policy on what action to take with unknown host keys",
 		Long: "What action to take when an unknown host key is encountered." +
 			" By default, this will mimic OpenSSH behavior and ask interactively, if possible." +
+			" If `confirmation.always` is set, then 'ask' will be overridden to 'accept-new'." +
 			" If turned off, then known_hosts will not be modified and man-in-the-middle attacks" +
 			" may be possible. Mostly a direct equivalent OpenSSH `StrictHostKeyChecking` setting.",
 	},

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -77,9 +77,10 @@ type RootCommandSettings struct {
 }
 
 type SSHSettings struct {
-	HostsFileCompletion bool     `koanf:"hosts_file_completion"`
-	KnownHostsFiles     []string `koanf:"known_hosts_files"`
-	PrivateKeyCmd       []string `koanf:"private_key_cmd"`
+	HostsFileCompletion bool                    `koanf:"hosts_file_completion"`
+	KnownHostsFiles     []string                `koanf:"known_hosts_files"`
+	PrivateKeyCmd       []string                `koanf:"private_key_cmd"`
+	HostKeyVerification HostKeyVerificationType `koanf:"host_key_verification"`
 }
 
 type ConfirmationPromptBehavior string
@@ -90,6 +91,23 @@ const (
 	ConfirmationPromptDefaultNo  ConfirmationPromptBehavior = "default-no"
 )
 
+var AvailableConfirmationPromptSettings = map[string]string{
+	string(ConfirmationPromptDefaultNo):  "Default to input of 'no'",
+	string(ConfirmationPromptDefaultYes): "Default to input of 'yes'",
+	string(ConfirmationPromptRetry):      "Retry the input function again",
+}
+
+func (c *ConfirmationPromptBehavior) UnmarshalText(text []byte) error {
+	val := ConfirmationPromptBehavior(text)
+	switch val {
+	case ConfirmationPromptDefaultYes, ConfirmationPromptDefaultNo, ConfirmationPromptRetry:
+		*c = val
+		return nil
+	}
+
+	return fmt.Errorf("invalid value for ConfirmationPromptBehavior '%s'", val)
+}
+
 type PasswordInputMethod string
 
 const (
@@ -98,21 +116,21 @@ const (
 	PasswordInputMethodNone  PasswordInputMethod = "none"
 )
 
-func (d *PasswordInputMethod) UnmarshalText(text []byte) error {
-	v := PasswordInputMethod(text)
-	switch v {
-	case PasswordInputMethodStdin, PasswordInputMethodTTY, PasswordInputMethodNone:
-		*d = v
-		return nil
-	default:
-		return fmt.Errorf("invalid value for password input method '%s'", text)
-	}
-}
-
 var AvailablePasswordInputMethods = map[string]string{
 	string(PasswordInputMethodStdin): "Prompt for the password once and pass it on stdin for all invocations",
 	string(PasswordInputMethodTTY):   "Allocate a TTY and always use interactive input for password",
 	string(PasswordInputMethodNone):  "Fail if command requires authentication",
+}
+
+func (p *PasswordInputMethod) UnmarshalText(text []byte) error {
+	v := PasswordInputMethod(text)
+	switch v {
+	case PasswordInputMethodStdin, PasswordInputMethodTTY, PasswordInputMethodNone:
+		*p = v
+		return nil
+	default:
+		return fmt.Errorf("invalid value for password input method '%s'", text)
+	}
 }
 
 type DiffTool string
@@ -140,21 +158,31 @@ func (d *DiffTool) UnmarshalText(text []byte) error {
 	}
 }
 
-var AvailableConfirmationPromptSettings = map[string]string{
-	string(ConfirmationPromptDefaultNo):  "Default to input of 'no'",
-	string(ConfirmationPromptDefaultYes): "Default to input of 'yes'",
-	string(ConfirmationPromptRetry):      "Retry the input function again",
+type HostKeyVerificationType string
+
+const (
+	HostKeyVerificationAcceptNew HostKeyVerificationType = "accept-new"
+	HostKeyVerificationAsk       HostKeyVerificationType = "ask"
+	HostKeyVerificationStrict    HostKeyVerificationType = "strict"
+	HostKeyVerificationOff       HostKeyVerificationType = "off"
+)
+
+var AvailableHostKeyVerificationOptions = map[string]string{
+	string(HostKeyVerificationAcceptNew): "Automatically accept new keys into known_hosts",
+	string(HostKeyVerificationAsk):       "Ask whether to add new keys to known_hosts",
+	string(HostKeyVerificationOff):       "Turn off all host key verification",
+	string(HostKeyVerificationStrict):    "Deny all keys that do not already exist in known_hosts",
 }
 
-func (c *ConfirmationPromptBehavior) UnmarshalText(text []byte) error {
-	val := ConfirmationPromptBehavior(text)
-	switch val {
-	case ConfirmationPromptDefaultYes, ConfirmationPromptDefaultNo, ConfirmationPromptRetry:
-		*c = val
+func (h *HostKeyVerificationType) UnmarshalText(text []byte) error {
+	v := HostKeyVerificationType(text)
+	switch v {
+	case HostKeyVerificationAcceptNew, HostKeyVerificationAsk, HostKeyVerificationOff, HostKeyVerificationStrict:
+		*h = v
 		return nil
+	default:
+		return fmt.Errorf("invalid value for host key verification '%s'", text)
 	}
-
-	return fmt.Errorf("invalid value for ConfirmationPromptBehavior '%s'", val)
 }
 
 type SettingsDocEntry struct {
@@ -342,6 +370,13 @@ This requires the 'nix-command' experimental feature to be enabled in the Nix co
 		Short: "Use hosts file for SSH host completion",
 		Long:  "Whether to use the hosts file (/etc/hosts) for SSH host completion.",
 	},
+	"ssh.host_key_verification": {
+		Short: "Policy on what action to take with unknown host keys",
+		Long: "What action to take when an unknown host key is encountered." +
+			" By default, this will mimic OpenSSH behavior and ask interactively, if possible." +
+			" If turned off, then known_hosts will not be modified and man-in-the-middle attacks" +
+			" may be possible. Mostly a direct equivalent OpenSSH `StrictHostKeyChecking` setting.",
+	},
 	"ssh.known_hosts_files": {
 		Short: "List of paths to known hosts files",
 		Long:  "List of paths to known hosts files. `/etc/ssh/ssh_known_hosts` and `$HOME/.ssh/known_hosts` are always included.",
@@ -416,6 +451,7 @@ func NewSettings() *Settings {
 		},
 		SSH: SSHSettings{
 			HostsFileCompletion: true,
+			HostKeyVerification: HostKeyVerificationAsk,
 		},
 		UseDefaultAliases: true,
 	}

--- a/internal/system/ssh.go
+++ b/internal/system/ssh.go
@@ -50,9 +50,10 @@ type SSHConfig struct {
 }
 
 type SSHConfigOptions struct {
-	AgentManager    *sshUtils.AgentManager
-	KnownHostsFiles []string
-	PrivateKeyCmd   []string
+	AgentManager        *sshUtils.AgentManager
+	KnownHostsFiles     []string
+	HostKeyVerification settings.HostKeyVerificationType
+	PrivateKeyCmd       []string
 }
 
 // Initialize a new SSH configuration that can be passed
@@ -61,6 +62,10 @@ type SSHConfigOptions struct {
 // The context is required to construct the password callback
 // such that it can be canceled gracefully.
 func NewSSHConfig(ctx context.Context, host string, log logger.Logger, options SSHConfigOptions) (*SSHConfig, error) {
+	if options.HostKeyVerification == "" {
+		return nil, errors.New("options.HostKeyVerification is empty")
+	}
+
 	// Parse the user@address:port SSH host string
 	if after, ok := strings.CutPrefix(host, "ssh://"); ok {
 		host = after
@@ -162,7 +167,7 @@ func NewSSHConfig(ctx context.Context, host string, log logger.Logger, options S
 	})
 	auth = append(auth, passwordCallback)
 
-	hostKeyCallback, err := knownHostsCallback(log, options.KnownHostsFiles)
+	hostKeyCallback, err := knownHostsCallback(log, options.HostKeyVerification, options.KnownHostsFiles)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +178,11 @@ func NewSSHConfig(ctx context.Context, host string, log logger.Logger, options S
 	return cfg, nil
 }
 
-func knownHostsCallback(log logger.Logger, extraKnownHosts []string) (ssh.HostKeyCallback, error) {
+func knownHostsCallback(
+	log logger.Logger,
+	hostKeyVerification settings.HostKeyVerificationType,
+	extraKnownHosts []string,
+) (ssh.HostKeyCallback, error) {
 	var knownHostsFiles []string
 
 	// By default, use /etc/ssh/ssh_known_hosts and $HOME/.ssh/known_hosts.
@@ -213,7 +222,7 @@ func knownHostsCallback(log logger.Logger, extraKnownHosts []string) (ssh.HostKe
 	}
 
 	if knownHostsUserFile != "" {
-		return addKeyToKnownHostsCallback(log, knownHostsKeyCallback, knownHostsUserFile), nil
+		return addKeyToKnownHostsCallback(log, knownHostsKeyCallback, hostKeyVerification, knownHostsUserFile), nil
 	} else {
 		return knownHostsKeyCallback, nil
 	}
@@ -316,57 +325,28 @@ func runPrivateKeyCmd(s *LocalSystem, host string, username string, privateKeyCm
 // This mimics the automatic addition of known_hosts entries
 // to the known_hosts file that OpenSSH performs.
 //
-// Only occurs if the key is not already in known_hosts and
-// if running in interactive mode in a terminal. Otherwise,
-// this will result in failure to connect.
-func addKeyToKnownHostsCallback(log logger.Logger, origCallback ssh.HostKeyCallback, knownHostsPath string) ssh.HostKeyCallback {
+// The behavior of this function depends on the `hostKeyVerification`
+// parameter
+func addKeyToKnownHostsCallback(
+	log logger.Logger,
+	origCallback ssh.HostKeyCallback,
+	hostKeyVerification settings.HostKeyVerificationType,
+	knownHostsPath string,
+) ssh.HostKeyCallback {
 	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
 		err := origCallback(hostname, remote, key)
 		if err == nil {
 			return nil
 		}
 
-		if keyErr, ok := errors.AsType[*knownhosts.KeyError](err); ok {
-			// Only allow adding the key like OpenSSH does if the
-			// stdin terminal can accept input.
-			if !term.IsTerminal(int(os.Stdin.Fd())) {
-				return err
-			}
+		keyErr, ok := errors.AsType[*knownhosts.KeyError](err)
+		if !ok {
+			return err
+		}
 
-			if len(keyErr.Want) == 0 {
-				fingerprint := ssh.FingerprintSHA256(key)
-				log.Infof("the authenticity of host '%s' (%s) can't be established", hostname, key.Type())
-				log.Infof("SHA256 fingerprint: %s", fingerprint)
-
-				var confirm bool
-				confirm, err = cmdUtils.ConfirmationInput("Are you sure you want to continue connecting?", cmdUtils.ConfirmationPromptOptions{
-					// Copy the default SSH behavior of retrying for invalid input.
-					// Disregard user configuration in this case, since this is mimicking
-					// OpenSSH's behavior.
-					InvalidBehavior: settings.ConfirmationPromptRetry,
-					EmptyBehavior:   settings.ConfirmationPromptRetry,
-				})
-				if err != nil {
-					log.Errorf("failed to get confirmation: %v", err)
-					return err
-				}
-				if !confirm {
-					return fmt.Errorf("user declined unknown host")
-				}
-
-				var knownHostsFile *os.File
-				knownHostsFile, err = os.OpenFile(knownHostsPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
-				if err != nil {
-					return fmt.Errorf("failed to open known_hosts: %w", err)
-				}
-				defer func() { _ = knownHostsFile.Close() }()
-
-				line := knownhosts.Line([]string{hostname}, key)
-				if _, err = knownHostsFile.WriteString(line + "\n"); err != nil {
-					return fmt.Errorf("failed to write to known_hosts: %w", err)
-				}
-
-				log.Warnf("permanently added '%s' (%s) to the list of known hosts", hostname, key.Type())
+		if len(keyErr.Want) > 0 {
+			if hostKeyVerification == settings.HostKeyVerificationOff {
+				log.Warnf("host key verification is off; using key %s", ssh.FingerprintSHA256(key))
 				return nil
 			}
 
@@ -381,7 +361,58 @@ func addKeyToKnownHostsCallback(log logger.Logger, origCallback ssh.HostKeyCallb
 			)
 		}
 
-		return err
+		switch hostKeyVerification {
+		case settings.HostKeyVerificationOff:
+			log.Debugf("host key verification is off; using key %s", ssh.FingerprintSHA256(key))
+			return nil
+		case settings.HostKeyVerificationAcceptNew:
+			// Do nothing, continue adding the key
+		case settings.HostKeyVerificationAsk:
+			// Only allow adding the key like OpenSSH does if the
+			// stdin terminal can accept input.
+			if !term.IsTerminal(int(os.Stdin.Fd())) {
+				return fmt.Errorf("no host key is known for %v", hostname)
+			}
+
+			fingerprint := ssh.FingerprintSHA256(key)
+			log.Infof("the authenticity of host '%s' (%s) can't be established", hostname, key.Type())
+			log.Infof("SHA256 fingerprint: %s", fingerprint)
+
+			var confirm bool
+			confirm, err = cmdUtils.ConfirmationInput("Are you sure you want to continue connecting?", cmdUtils.ConfirmationPromptOptions{
+				// Copy the default SSH behavior of retrying for invalid input.
+				// Disregard user configuration in this case, since this is mimicking
+				// OpenSSH's behavior.
+				InvalidBehavior: settings.ConfirmationPromptRetry,
+				EmptyBehavior:   settings.ConfirmationPromptRetry,
+			})
+			if err != nil {
+				log.Errorf("failed to get confirmation: %v", err)
+				return err
+			}
+			if !confirm {
+				return fmt.Errorf("user declined unknown host")
+			}
+		case settings.HostKeyVerificationStrict:
+			return fmt.Errorf("no host key is known for %v and strict host key checking was requested", hostname)
+		default:
+			panic(fmt.Sprintf("unexpected settings.HostKeyVerificationType: %#v", hostKeyVerification))
+		}
+
+		var knownHostsFile *os.File
+		knownHostsFile, err = os.OpenFile(knownHostsPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+		if err != nil {
+			return fmt.Errorf("failed to open known_hosts: %w", err)
+		}
+		defer func() { _ = knownHostsFile.Close() }()
+
+		line := knownhosts.Line([]string{hostname}, key)
+		if _, err = knownHostsFile.WriteString(line + "\n"); err != nil {
+			return fmt.Errorf("failed to write to known_hosts: %w", err)
+		}
+
+		log.Warnf("permanently added '%s' (%s) to the list of known hosts", hostname, key.Type())
+		return nil
 	}
 }
 


### PR DESCRIPTION
To further enable non-interactive `apply` workflows, this PR creates a new SSH `known_hosts` key policy setting that mostly corresponds to the functionality of OpenSSH's `StrictHostKeyChecking` setting.

By default, it is set to `ask` (the previous behavior as well), but it can be changed to `accept-new` to always accept host keys, `off` to disable host key checking entirely, and `strict` to deny unknown host keys. Any `-y` flags or disabling of confirmation prompts will change the default `ask` behavior to `accept-new` to allow for non-interactive execution of `nixos-cli` with new/unknown host keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SSH host key verification configuration with four modes: accept-new (auto-accept new keys), ask (prompt for unknown keys), strict (reject unknown keys), and off (disable verification).
  * Host key verification behavior automatically adapts based on confirmation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->