### PR TITLE
fix(input): allow canceling confirmation input using context

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -646,7 +646,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 		log.Printf("\n")
 
 		var confirm bool
-		confirm, err = cmdUtils.ConfirmationInput("Activate this configuration?", cmdUtils.ConfirmationPromptOptions{
+		confirm, err = cmdUtils.ConfirmationInput(stopCtx, "Activate this configuration?", cmdUtils.ConfirmationPromptOptions{
 			InvalidBehavior: cfg.Confirmation.Invalid,
 			EmptyBehavior:   cfg.Confirmation.Empty,
 		})

--- a/cmd/generation/delete/delete.go
+++ b/cmd/generation/delete/delete.go
@@ -160,7 +160,7 @@ func generationDeleteMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts, o
 
 	if !opts.AlwaysConfirm && !cfg.Confirmation.Always {
 		var confirm bool
-		confirm, err = cmdUtils.ConfirmationInput("Proceed?", cmdUtils.ConfirmationPromptOptions{
+		confirm, err = cmdUtils.ConfirmationInput(cmd.Context(), "Proceed?", cmdUtils.ConfirmationPromptOptions{
 			InvalidBehavior: cfg.Confirmation.Invalid,
 			EmptyBehavior:   cfg.Confirmation.Empty,
 		})

--- a/cmd/generation/rollback/rollback.go
+++ b/cmd/generation/rollback/rollback.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/nix-community/nixos-cli/cmd/generation/shared"
+	genUtils "github.com/nix-community/nixos-cli/cmd/generation/shared"
 	"github.com/nix-community/nixos-cli/internal/activation"
-	"github.com/nix-community/nixos-cli/internal/cmd/opts"
-	"github.com/nix-community/nixos-cli/internal/cmd/utils"
+	cmdOpts "github.com/nix-community/nixos-cli/internal/cmd/opts"
+	cmdUtils "github.com/nix-community/nixos-cli/internal/cmd/utils"
 	"github.com/nix-community/nixos-cli/internal/constants"
 	"github.com/nix-community/nixos-cli/internal/diff"
 	"github.com/nix-community/nixos-cli/internal/generation"
@@ -98,7 +98,7 @@ func generationRollbackMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts,
 		log.Printf("\n")
 
 		var confirm bool
-		confirm, err = cmdUtils.ConfirmationInput("Activate the previous generation?", cmdUtils.ConfirmationPromptOptions{
+		confirm, err = cmdUtils.ConfirmationInput(cmd.Context(), "Activate the previous generation?", cmdUtils.ConfirmationPromptOptions{
 			InvalidBehavior: cfg.Confirmation.Invalid,
 			EmptyBehavior:   cfg.Confirmation.Empty,
 		})

--- a/cmd/generation/switch/switch.go
+++ b/cmd/generation/switch/switch.go
@@ -150,7 +150,7 @@ func generationSwitchMain(cmd *cobra.Command, genOpts *cmdOpts.GenerationOpts, o
 		log.Printf("\n")
 
 		var confirm bool
-		confirm, err = cmdUtils.ConfirmationInput("Activate this generation?", cmdUtils.ConfirmationPromptOptions{
+		confirm, err = cmdUtils.ConfirmationInput(cmd.Context(), "Activate this generation?", cmdUtils.ConfirmationPromptOptions{
 			InvalidBehavior: cfg.Confirmation.Invalid,
 			EmptyBehavior:   cfg.Confirmation.Empty,
 		})

--- a/internal/cmd/utils/confirmation.go
+++ b/internal/cmd/utils/confirmation.go
@@ -2,6 +2,7 @@ package cmdUtils
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -15,56 +16,112 @@ type ConfirmationPromptOptions struct {
 	EmptyBehavior   settings.ConfirmationPromptBehavior
 }
 
-func ConfirmationInput(msg string, opts ConfirmationPromptOptions) (bool, error) {
+// This operation can be cancelled using the provided context,
+// but any errors returned from here MAY have the potential
+// to keep consuming stdin until another character is typed
+// if a duplicate instance of stdin cannot be opened, so
+// any errors here will result in potentially undefined behavior
+// for stdin input.
+func ConfirmationInput(ctx context.Context, msg string, opts ConfirmationPromptOptions) (bool, error) {
+	var stdin *os.File
+	if dupStdin, err := os.OpenFile("/dev/stdin", os.O_RDONLY, 0); err == nil {
+		defer dupStdin.Close()
+		stdin = dupStdin
+	} else {
+		// NOTE: falling back to stdin will make context
+		// cancellation behavior a bit unclear, as mentioned
+		// in the doc comment.
+		stdin = os.Stdin
+	}
+
 	var input string
-	scanner := bufio.NewScanner(os.Stdin)
+	scanner := bufio.NewScanner(stdin)
+
+	inputCh := make(chan string)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(inputCh)
+
+		for scanner.Scan() {
+			select {
+			case inputCh <- scanner.Text():
+			case <-ctx.Done():
+				return
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			select {
+			case errCh <- err:
+			default:
+			}
+		}
+	}()
 
 	for {
 		fmt.Fprintf(os.Stderr, "%s\n[y/n]: ", color.GreenString("|> %s", msg))
 
-		_ = scanner.Scan()
-		input = scanner.Text()
-		if err := scanner.Err(); err != nil {
-			return false, err
-		}
+		var ok bool
+		var err error
 
-		input = strings.ToLower(strings.TrimSpace(input))
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
 
-		if len(input) == 0 {
-			switch opts.EmptyBehavior {
+		case err, ok = <-errCh:
+			if !ok {
+				return false, nil
+			}
+
+			if err != nil {
+				return false, err
+			}
+			return false, nil
+
+		case input, ok = <-inputCh:
+			if !ok {
+				return false, nil
+			}
+
+			input = strings.ToLower(strings.TrimSpace(input))
+
+			if len(input) == 0 {
+				switch opts.EmptyBehavior {
+				case settings.ConfirmationPromptRetry:
+					fmt.Fprintln(os.Stderr, "error: input must not be empty")
+					continue
+				case settings.ConfirmationPromptDefaultNo:
+					fmt.Fprintln(os.Stderr, "no input provided; defaulting to no")
+					return false, nil
+				case settings.ConfirmationPromptDefaultYes:
+					fmt.Fprintln(os.Stderr, "no input provided; defaulting to yes")
+					return true, nil
+				default:
+					return false, fmt.Errorf("unhandled EmptyBehavior case: %s", opts.EmptyBehavior)
+				}
+			}
+
+			switch input[0] {
+			case 'y':
+				return true, nil
+			case 'n':
+				return false, nil
+			}
+
+			switch opts.InvalidBehavior {
 			case settings.ConfirmationPromptRetry:
-				fmt.Fprintln(os.Stderr, "error: input must not be empty")
+				fmt.Fprintf(os.Stderr, "error: invalid input '%s'; must be y/n\n", input)
 				continue
 			case settings.ConfirmationPromptDefaultNo:
-				fmt.Fprintln(os.Stderr, "no input provided; defaulting to no")
+				fmt.Fprintf(os.Stderr, "warning: invalid input '%s'; defaulting to no\n", input)
 				return false, nil
 			case settings.ConfirmationPromptDefaultYes:
-				fmt.Fprintln(os.Stderr, "no input provided; defaulting to yes")
+				fmt.Fprintf(os.Stderr, "warning: invalid input '%s'; defaulting to yes\n", input)
 				return true, nil
 			default:
-				return false, fmt.Errorf("unhandled EmptyBehavior case: %s", opts.EmptyBehavior)
+				return false, fmt.Errorf("unhandled InvalidBehavior case: %s", opts.InvalidBehavior)
 			}
-		}
-
-		switch input[0] {
-		case 'y':
-			return true, nil
-		case 'n':
-			return false, nil
-		}
-
-		switch opts.InvalidBehavior {
-		case settings.ConfirmationPromptRetry:
-			fmt.Fprintf(os.Stderr, "error: invalid input '%s'; must be y/n\n", input)
-			continue
-		case settings.ConfirmationPromptDefaultNo:
-			fmt.Fprintf(os.Stderr, "warning: invalid input '%s'; defaulting to no\n", input)
-			return false, nil
-		case settings.ConfirmationPromptDefaultYes:
-			fmt.Fprintf(os.Stderr, "warning: invalid input '%s'; defaulting to yes\n", input)
-			return true, nil
-		default:
-			return false, fmt.Errorf("unhandled InvalidBehavior case: %s", opts.InvalidBehavior)
 		}
 	}
 }

--- a/internal/system/ssh.go
+++ b/internal/system/ssh.go
@@ -381,7 +381,7 @@ func addKeyToKnownHostsCallback(
 			log.Infof("SHA256 fingerprint: %s", fingerprint)
 
 			var confirm bool
-			confirm, err = cmdUtils.ConfirmationInput("Are you sure you want to continue connecting?", cmdUtils.ConfirmationPromptOptions{
+			confirm, err = cmdUtils.ConfirmationInput(context.Background(), "Are you sure you want to continue connecting?", cmdUtils.ConfirmationPromptOptions{
 				// Copy the default SSH behavior of retrying for invalid input.
 				// Disregard user configuration in this case, since this is mimicking
 				// OpenSSH's behavior.


### PR DESCRIPTION
The confirmation input would hang due to a blocking read on stdin, similar to the previous password reading behavior.

This PR makes the confirmation input function cancellable by duplicating the stdin file handle.