### PR TITLE
feat(configuration): add support for system.nix entrypoint

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -178,7 +178,7 @@ func ApplyCommand(cfg *settings.Settings) *cobra.Command {
 				}
 				return ref
 			} else {
-				configPath, err := utils.ResolveNixFilename(args[0])
+				configPath, err := configuration.ResolveSystemNix(args[0])
 				if err != nil {
 					return nil
 				}
@@ -492,7 +492,7 @@ func applyMain(cmd *cobra.Command, opts *cmdOpts.ApplyOpts) error {
 			}
 		} else if opts.File != "" {
 			var configPath string
-			configPath, err = utils.ResolveNixFilename(opts.File)
+			configPath, err = configuration.ResolveSystemNix(opts.File)
 			if err != nil {
 				log.Error(err)
 				return err

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -183,8 +183,9 @@ Arguments:
   [ATTR]  Attribute inside of [FILE] pointing to configuration
 
   Both arguments are optional. If [FILE] is not specified, then
-  $root/etc/nixos/configuration.nix is used. If [ATTR] is not
-  specified, then the top-level attribute of [FILE] is used.
+  $root/etc/nixos/configuration.nix is used as an implicit
+  configuration. If [ATTR] is not specified, then the top-level
+  attribute of [FILE] is used.
 `
 	}
 	helpTemplate += `
@@ -453,7 +454,7 @@ func installMain(cmd *cobra.Command, opts *cmdOpts.InstallOpts) error {
 			log.Debugf("using flake ref %s", opts.FlakeRef)
 		} else if opts.File != "" {
 			var configPath string
-			configPath, err = utils.ResolveNixFilename(opts.File)
+			configPath, err = configuration.ResolveSystemNix(opts.File)
 			if err != nil {
 				log.Error(err)
 				return err
@@ -514,7 +515,7 @@ func installMain(cmd *cobra.Command, opts *cmdOpts.InstallOpts) error {
 			envMap["TMPDIR"] = tmpDirname
 		}
 
-		if c, ok := nixConfig.(*configuration.LegacyConfiguration); ok {
+		if c, ok := nixConfig.(*configuration.LegacyConfiguration); ok && !c.UseExplicitPath {
 			// This value gets appended to the list of includes,
 			// and does not replace existing values already provided
 			// for -I on the command line.

--- a/cmd/option/option.go
+++ b/cmd/option/option.go
@@ -15,7 +15,6 @@ import (
 	"github.com/nix-community/nixos-cli/internal/logger"
 	"github.com/nix-community/nixos-cli/internal/settings"
 	"github.com/nix-community/nixos-cli/internal/system"
-	"github.com/nix-community/nixos-cli/internal/utils"
 	"github.com/sahilm/fuzzy"
 	"github.com/spf13/cobra"
 	"github.com/yarlson/pin"
@@ -120,7 +119,7 @@ func optionMain(cmd *cobra.Command, opts *cmdOpts.OptionOpts) error {
 		}
 		nixosConfig = ref
 	} else if opts.File != "" {
-		configPath, err := utils.ResolveNixFilename(opts.File)
+		configPath, err := configuration.ResolveSystemNix(opts.File)
 		if err != nil {
 			log.Error(err)
 			return err

--- a/cmd/repl/repl.go
+++ b/cmd/repl/repl.go
@@ -13,7 +13,6 @@ import (
 	"github.com/nix-community/nixos-cli/internal/configuration"
 	"github.com/nix-community/nixos-cli/internal/logger"
 	"github.com/nix-community/nixos-cli/internal/settings"
-	"github.com/nix-community/nixos-cli/internal/utils"
 	"github.com/spf13/cobra"
 
 	"github.com/nix-community/nixos-cli/internal/build"
@@ -167,7 +166,7 @@ func replMain(cmd *cobra.Command, opts *cmdOpts.ReplOpts) error {
 		}
 		nixosConfig = ref
 	} else if opts.File != "" {
-		configPath, err := utils.ResolveNixFilename(opts.File)
+		configPath, err := configuration.ResolveSystemNix(opts.File)
 		if err != nil {
 			log.Error(err)
 			return err

--- a/doc/man/nixos-cli-apply.1.scd
+++ b/doc/man/nixos-cli-apply.1.scd
@@ -27,6 +27,9 @@ This command behaves slightly differently based on if it is flake-enabled
 or not, and this requirement will be specified for the relevant options
 and sections.
 
+Important: see *nixos-cli-config(5)* for a detailed description of how to
+specify NixOS configuration parameters, and how they are discovered.
+
 # EXAMPLES
 
 Many behaviors are similar to the _nixos-rebuild_ command of old. Here are some
@@ -44,13 +47,13 @@ _nixos-rebuild switch_, on an arbitrary flake ref (for flake-enabled CLIs only)
 
 	*nixos apply "github:water-sucks/nixed#CharlesWoodson"*
 
-_nixos-rebuild switch_, on an arbitrary Nix file containing a configuration (for
-legacy CLIs only):
+_nixos-rebuild switch_, on an arbitrary Nix file containing an explicit
+configuration (for legacy CLIs only):
 
 	*nixos apply /home/user/.nixconfig/config.nix*
 
-_nixos-rebuild switch_, on an arbitrary Nix file containing multiple
-configurations in an attribute set (for legacy CLIs only):
+_nixos-rebuild switch_, on an arbitrary Nix configuration containing multiple
+systems in an attribute set (for legacy CLIs only):
 
 	*nixos apply /home/user/.nixconfig/machines.nix SebastianJanikowski*
 
@@ -87,20 +90,20 @@ command tree. See *nixos-cli-generation(1)* for details.
 	Specify an explicit flake ref with a NixOS configuration. Only available
 	on flake-enabled CLIs.
 
-	See *nixos-config-env(5)* for the proper flake ref format.
+	See *nixos-cli-config(5)* for the proper flake ref format.
 
 	Default: *$NIXOS_CONFIG*
 
 *FILE*
-	Specify an explicit path to a Nix file containing a NixOS configuration.
+	Specify a path to a Nix file containing an explicit NixOS configuration.
 
 	Only available on legacy CLIs.
 
-	This argument is useful for building a NixOS system from a Nix file that is
-	not a flake or a NixOS configuration module.
+	This argument can only be used to build explicit configurations.
 
-	If not specified, then the value in the environment variable _$NIXOS_CONFIG_
-	or the value of the _nixos-config_ entry in _$NIX_PATH_ will be used.
+	If not specified, then explicit configurations will be auto-discovered in
+	the order described in *nixos-cli-config(5)*. If no explicit configurations
+	are found, then implicit ones will be auto-discovered and used.
 
 *ATTR*
 	Use the specified attribute path inside of *FILE* as the NixOS system to
@@ -109,7 +112,8 @@ command tree. See *nixos-cli-generation(1)* for details.
 	Only available on legacy CLIs.
 
 	If *ATTR* is not specified, then the top-level attribute of *FILE* will be
-	used.
+	used, or the selected attribute from _$NIXOS_SYSTEM_ or the _<nixos-system>_
+	entry in _$NIX_PATH_ if it exists.
 
 # OPTIONS
 
@@ -433,6 +437,8 @@ this:
 *nix3-build*(1), *nix-build(1)*
 
 *nix-env(1)*
+
+*nixos-cli-config*(5)
 
 *nixos-cli-env*(5)
 

--- a/doc/man/nixos-cli-config.5.scd
+++ b/doc/man/nixos-cli-config.5.scd
@@ -1,0 +1,143 @@
+NIXOS-CLI-CONFIG(5)
+
+# NAME
+
+nixos-cli-config - how NixOS configurations work in _nixos-cli_
+
+# DESCRIPTION
+
+*nixos-cli* primarily works with NixOS configurations.
+
+A *configuration* in this document is defined as the entrypoint from
+which a NixOS system is built.
+
+This can take three forms:
+
+- *Flake references* (abbreviated as flake "refs")
+- *Explicit* configurations (Nix files that contain NixOS configurations)
+- *Implicit* configurations (A Nix module that gets imported by 
+  *<nixpkgs/nixos>*)
+
+Flake-enabled CLIs only support flake references.
+
+Legacy CLIs support both explicit and implicit configurations, and will
+prioritize explicit ones over implicit ones.
+
+## FLAKE REFERENCES
+
+Note: these are only supported in flake-enabled CLIs.
+
+Flake refs have a two-part format: *<URI>*#*<SYSTEM>*.
+
+The *URI* can be any valid Nix filesystem tree containing a _flake.nix_ file in
+the root. More information on the URI format can be found in *nix3-flake(1)*.
+
+The *SYSTEM* portion corresponds to an attribute under the _nixosConfigurations_
+output in the flake schema. They will usually be expanded when necessary. For
+example, the following NixOS configuration flake ref:
+
+	_github:water-sucks/nixed#CharlesWoodson_
+
+will get expanded to the following flake ref and attribute:
+
+	_github:water-sucks/nixed#nixosConfigurations.CharlesWoodson_
+
+If the ref does not have text after the "#", then the NixOS system attribute
+name will be inferred to be the current system's hostname unless otherwise
+specified.
+
+Flake refs without a local path may have slightly different behavior, such as
+not supporting implicit Git operations. Check relevant man pages for more
+information.
+
+## EXPLICIT CONFIGURATIONS
+
+Note: these are only supported in legacy CLIs.
+
+Explicit configurations are self-contained Nix files that can be built
+without relying on _$NIX_PATH_ or Nix channels.
+
+Example:
+
+```
+let
+  nixpkgs = fetchTarball {
+    name = "nixos-unstable-2026-04-20";
+    url = "https://github.com/NixOS/nixpkgs/archive/b12141ef619e0a9c1c84dc8c684040326f27cdcc.zip";
+    sha256 = "0vhprxh6zqrc8bc745crfzs75cl1sqls3hdldlairm0spqsb88k5";
+  };
+in
+  import "${nixpkgs}/nixos" {
+    configuration = ./configuration.nix;
+  }
+```
+
+_configuration.nix_ would be the entrypoint for the NixOS module that gets
+imported.
+
+Explicit configurations come in two forms; they can either contain a single
+toplevel attribute that contains a buildable NixOS system, or they can contain
+an attribute set of many NixOS systems.
+
+Example:
+
+```
+let
+  nixpkgs = fetchTarball {
+    name = "nixos-unstable-2026-04-20";
+    url = "https://github.com/NixOS/nixpkgs/archive/b12141ef619e0a9c1c84dc8c684040326f27cdcc.zip";
+    sha256 = "0vhprxh6zqrc8bc745crfzs75cl1sqls3hdldlairm0spqsb88k5";
+  };
+
+  nixosSystem = configuration: import "${nixpkgs}/nixos" {
+    inherit configuration;
+  };
+in {
+  BoJackson = nixosSystem ./systems/BoJackson.nix;
+  CharlesWoodson = nixosSystem ./systems/CharlesWoodson.nix;
+  SebastianJanikowski = nixosSystem ./systems/SebastianJanikowski.nix;
+}
+```
+
+Note: these attributes can also be nested as desired; however, the selected
+attribute must be a valid, buildable NixOS system.
+
+Explicit configurations are usually discovered in the following order for
+most commands, unless otherwise specified:
+
+- *$NIXOS_SYSTEM* (environment variable)
+- *<nixos-system>* (_$NIX_PATH_ entry)
+- *config_location* setting (this can also be a directory containing a 
+  _system.nix_ file; does not support passing attributes)
+
+Both *$NIXOS_SYSTEM* and the *<nixos-system>* entry in _$NIX_PATH_ can specify
+an attribute to build by suffixing the path with a #. Example values for these:
+
+- _/etc/nixos/system.nix_ (uses top-level attribute)
+- _/path/to/system.nix#BoJackson_ (selects the BoJackson attribute)
+
+## IMPLICIT CONFIGURATIONS
+
+An *implicit configuration* is a path to a NixOS module that serves as the
+entrypoint to a single NixOS system.
+
+Unlike an explicit configuration, it always relies on a _<nixpkgs>_ entry in
+_$NIX_PATH_ being present, and will automatically import _<nixpkgs/nixos>_ and
+pass this module to it.
+
+Implicit configurations are usually discovered in the following order for most
+commands, unless otherwise specified:
+
+- *$NIXOS_CONFIG* (environment variable)
+- *<nixos-config>* (_$NIX_PATH_ entry)
+
+# SEE ALSO
+
+*nixos-cli-env(5)*
+
+*nixos-cli-settings(5)*
+
+# AUTHORS
+
+Maintained by the *nixos-cli* team. See the main man page *nixos-cli(1)* for
+details.

--- a/doc/man/nixos-cli-env.5.scd
+++ b/doc/man/nixos-cli-env.5.scd
@@ -38,32 +38,24 @@ Among other things.
 		This must be a valid flake ref (e.g., */home/user/config* or
 		*github:myorg/nixos-config#attr*).
 
-		Flake refs without a local path may have slightly different behavior,
-		such as not supporting implicit Git operations. Check relevant man pages
-		for more information.
-
-		If a flake ref is a path, it _MUST_ be absolute. Use *realpath(1)* if
-		you must.
-
-		Additionally, flake refs will usually be expanded when necessary.
-		For example, the following flake ref:
-
-			_github:water-sucks/nixed#CharlesWoodson_
-
-		will get expanded to the following flake ref and attribute:
-
-			_github:water-sucks/nixed#nixosConfigurations.CharlesWoodson_
-
-		If the ref does not have text after the "#", then the NixOS system
-		attribute name will be inferred to be the current system's hostname.
+		See the flake reference section in *nixos-cli-config(5)* for more
+		information.
 
 	*Legacy CLIs:*
 		This can be a path to a configuration file directly
 		(*configuration.nix*), or a directory containing a *default.nix*.
 
-		Legacy configurations can also be sourced from the *$NIX_PATH*
-		environment variable, if the _nixos-config=<PATH>_ attribute is
-		specified there.
+		See the implicit configuration section in *nixos-cli-config(5)* for
+		more information.
+
+*NIXOS_SYSTEM*
+	Only applicable to legacy CLIs.
+
+	For entirely self-contained explicit configurations, _$NIXOS_SYSTEM_
+	can be used to pass them to _nixos-cli_ instead.
+
+	See the explicit configuration section in *nixos-cli-config(5)* for more
+	information.
 
 *NIXOS_GENERATION_TAG*
 	A description for the generation. Usually set by default through the *-t*
@@ -119,6 +111,8 @@ Do not set directly unless running this in development.
 # SEE ALSO
 
 *nixos-cli-config(5)*
+
+*nixos-cli-settings(5)*
 
 # AUTHORS
 

--- a/doc/man/nixos-cli-install.1.scd
+++ b/doc/man/nixos-cli-install.1.scd
@@ -30,9 +30,11 @@ If the CLI is flake-enabled:
 	  flake reference with a NixOS configuration.
 Otherwise:
 	- The *$NIXOS_CONFIG* variable must point to a valid NixOS configuration
-	  module or a directory containing a _default.nix_ with the same.
+	  module or a directory containing a _default.nix_ with the same. This
+	  will be treated as an implicit configuration.
 	- OR the target root must have a file at _/etc/nixos/configuration.nix_
-	- OR *FILE* + *ATTR* should be passed.
+	  (also an implicit configuration)
+	- OR *FILE* + *ATTR* should be passed (explicit configuration)
 
 The installation will take place relative to a specified root directory
 (defaults to `/mnt`). Mountpoints and all other filesystems must be mounted
@@ -100,7 +102,7 @@ is also possible, assuming a successful installation.
 	Specify an explicit flake ref to evaluate options from. Only available
 	on flake-enabled CLIs.
 
-	See *nixos-config-env(5)* for the proper flake ref format.
+	See *nixos-cli-config(5)* for the proper flake ref format.
 
 	The system name is NOT inferred from the hostname, and must be provided
 	explicitly after the #.
@@ -109,15 +111,14 @@ is also possible, assuming a successful installation.
 	CLI, the program will fail.
 
 *FILE*
-	Specify an explicit path to a Nix file containing a NixOS configuration.
+	Specify an path to a Nix file containing an explicit configuration, or to a
+	directory containing a _system.nix_ file with the same.
 
 	Only available on legacy CLIs.
 
-	This argument is useful for building a NixOS system from a Nix file that is
-	not a flake or a NixOS configuration module.
-
 	If not specified, then the value in the environment variable _$NIXOS_CONFIG_
-	or the value of the _nixos-config_ entry in _$NIX_PATH_ will be used.
+	or the file located in *root*_/etc/nixos/configuration.nix_ will be used as
+	an implicit configuration.
 
 *ATTR*
 	Use the specified attribute path inside of *FILE* as the NixOS system to
@@ -177,7 +178,7 @@ is also possible, assuming a successful installation.
 
 # NIX OPTIONS
 
-*nixos apply* accepts some Nix options and passes them through to their relevant
+*nixos install* accepts some Nix options and passes them through to their relevant
 Nix invocations.
 
 The following options are supported:
@@ -227,7 +228,9 @@ than as two arguments in the actual Nix CLI.
 
 *nix-env(1)*
 
-*nixos-cli-env*(5)
+*nixos-cli-config(5)*
+
+*nixos-cli-env(5)*
 
 # AUTHORS
 

--- a/internal/cmd/utils/completion/configuration.go
+++ b/internal/cmd/utils/completion/configuration.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/nix-community/nixos-cli/internal/cmd/nixopts"
-	"github.com/nix-community/nixos-cli/internal/utils"
+	"github.com/nix-community/nixos-cli/internal/configuration"
 	"github.com/spf13/cobra"
 )
 
@@ -68,7 +68,7 @@ func CompleteFlakeRefURI(toComplete string) []string {
 // contains attributes that can be evaluated directly and
 // correspond to NixOS configurations.
 func CompleteNixConfigFileAttr(filename string) ([]string, cobra.ShellCompDirective) {
-	configPath, err := utils.ResolveNixFilename(filename)
+	configPath, err := configuration.ResolveSystemNix(filename)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -64,12 +64,19 @@ func FindConfiguration(log logger.Logger, cfg *settings.Settings, includes []str
 
 		return f, nil
 	} else {
-		c, err := FindLegacyConfiguration(log, includes)
+		c, err := FindLegacyConfiguration(cfg, log, includes)
 		if err != nil {
 			return nil, err
 		}
 
 		log.Debugf("found legacy configuration at %s", c.ConfigPath)
+		if c.UseExplicitPath {
+			if c.Attribute == "" {
+				log.Debugf("using top-level attribute")
+			} else {
+				log.Debugf("using explicit attribute '%s'", c.Attribute)
+			}
+		}
 
 		return c, nil
 	}

--- a/internal/configuration/legacy.go
+++ b/internal/configuration/legacy.go
@@ -69,7 +69,7 @@ func FindLegacyConfiguration(cfg *settings.Settings, log logger.Logger, includes
 		if resolved, err := utils.ResolveNixFilename(config); err == nil {
 			config = resolved
 		} else {
-			log.Debugf("error when resolving %s to file: %s", resolved, err)
+			log.Debugf("error when resolving %s to file: %s", config, err)
 		}
 		return &LegacyConfiguration{
 			ConfigPath: config,
@@ -112,7 +112,7 @@ func findExplicitConfiguration(
 
 	log.Debugf("looking for system.nix in %s", cfg.ConfigLocation)
 
-	if _, err := os.Stat(cfg.ConfigLocation); err != nil {
+	if _, err := os.Stat(cfg.ConfigLocation); err == nil {
 		if utils.ContainsFile(cfg.ConfigLocation, "system.nix") {
 			return filepath.Join(cfg.ConfigLocation, "system.nix"), "", true
 		} else {
@@ -123,6 +123,29 @@ func findExplicitConfiguration(
 	}
 
 	return "", "", false
+}
+
+// If the passed file is a directory, then try to find a system.nix
+// file or a default.nix file in it. Otherwise, error out.
+func ResolveSystemNix(input string) (string, error) {
+	if utils.ContainsFile(input, "system.nix") {
+		joined := filepath.Join(input, "system.nix")
+
+		realPath, err := filepath.EvalSymlinks(joined)
+		if err != nil {
+			return "", err
+		}
+
+		absolutePath, err := filepath.Abs(realPath)
+		if err != nil {
+			return "", err
+		}
+
+		return absolutePath, nil
+
+	}
+
+	return utils.ResolveNixFilename(input)
 }
 
 func findImplicitConfiguration(
@@ -278,9 +301,9 @@ func (l *LegacyConfiguration) buildLocalSystem(s *system.LocalSystem, buildType 
 
 	log := s.Logger()
 
-	// if log.GetLogLevel() == logger.LogLevelDebug {
-	// 	argv = append(argv, "-v")
-	// }
+	if log.GetLogLevel() == logger.LogLevelDebug {
+		argv = append(argv, "-v")
+	}
 
 	log.CmdArray(argv)
 

--- a/internal/configuration/legacy.go
+++ b/internal/configuration/legacy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nix-community/nixos-cli/internal/cmd/nixopts"
 	"github.com/nix-community/nixos-cli/internal/logger"
 	"github.com/nix-community/nixos-cli/internal/nix"
+	"github.com/nix-community/nixos-cli/internal/settings"
 	"github.com/nix-community/nixos-cli/internal/system"
 	"github.com/nix-community/nixos-cli/internal/utils"
 )
@@ -32,50 +33,141 @@ type LegacyConfiguration struct {
 	Builder system.CommandRunner
 }
 
-func FindLegacyConfiguration(log logger.Logger, includes []string) (*LegacyConfiguration, error) {
+func FindLegacyConfiguration(cfg *settings.Settings, log logger.Logger, includes []string) (*LegacyConfiguration, error) {
 	log.Debugf("looking for legacy configuration")
 
-	var configPath string
-	if nixosCfg, set := os.LookupEnv("NIXOS_CONFIG"); set {
-		log.Debugf("$NIXOS_CONFIG is set, using automatically")
-		configPath = nixosCfg
+	// Order of priority when discovering configuration
+	// 1. Explicit (system)
+	//   - $NIXOS_SYSTEM (/path/to/file#attr)
+	//   - -I nixos-system=
+	//   - <nixos-system>
+	//   - ${configLocation}/system.nix
+	// 2. Implicit (importing <nixpkgs/nixos>)
+	//   - $NIXOS_CONFIG
+	//   - -I nixos-config=
+	//   - <nixos-config>
+
+	nixPathEntries := getNixPathEntries()
+
+	if config, attr, found := findExplicitConfiguration(cfg, log, includes, nixPathEntries); found {
+
+		if resolved, err := utils.ResolveNixFilename(config); err == nil {
+			config = resolved
+		} else {
+			log.Debugf("error when resolving %s to file: %s", config, err)
+		}
+		return &LegacyConfiguration{
+			ConfigPath:      config,
+			Attribute:       attr,
+			UseExplicitPath: true,
+			Includes:        includes,
+		}, nil
 	}
 
-	if configPath == "" && includes != nil {
-		for _, include := range includes {
-			if after, ok := strings.CutPrefix(include, "nixos-config="); ok {
-				configPath = after
-				break
-			}
+	if config, found := findImplicitConfiguration(log, includes, nixPathEntries); found {
+		// First, attempt to resolve the path from a directory if possible.
+		if resolved, err := utils.ResolveNixFilename(config); err == nil {
+			config = resolved
+		} else {
+			log.Debugf("error when resolving %s to file: %s", resolved, err)
+		}
+		return &LegacyConfiguration{
+			ConfigPath: config,
+			Includes:   includes,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("no configuration found")
+}
+
+func findExplicitConfiguration(
+	cfg *settings.Settings,
+	log logger.Logger,
+	includes []string,
+	nixPath map[string]string,
+) (string, string, bool) {
+	if config, set := os.LookupEnv("NIXOS_SYSTEM"); set {
+		log.Debug("$NIXOS_SYSTEM is set, using automatically")
+		path, attr, _ := strings.Cut(config, "#")
+		return path, attr, true
+	}
+
+	log.Debug("looking for nixos-system= entry in includes list")
+
+	for _, include := range includes {
+		if config, ok := strings.CutPrefix(include, "nixos-system="); ok {
+			log.Debug("found nixos-system= in include list")
+			path, attr, _ := strings.Cut(config, "#")
+			return path, attr, true
 		}
 	}
 
-	if configPath == "" {
-		log.Debugf("$NIXOS_CONFIG not set, using $NIX_PATH to find configuration")
+	log.Debug("looking for nixos-system= entry in $NIX_PATH")
 
-		nixPath := strings.SplitSeq(os.Getenv("NIX_PATH"), ":")
-		for entry := range nixPath {
-			if after, ok := strings.CutPrefix(entry, "nixos-config="); ok {
-				configPath = after
-				break
-			}
+	if config, ok := nixPath["nixos-system"]; ok {
+		log.Debug("found nixos-system entry in $NIX_PATH")
+		path, attr, _ := strings.Cut(config, "#")
+		return path, attr, true
+	}
+
+	log.Debugf("looking for system.nix in %s", cfg.ConfigLocation)
+
+	if _, err := os.Stat(cfg.ConfigLocation); err != nil {
+		if utils.ContainsFile(cfg.ConfigLocation, "system.nix") {
+			return filepath.Join(cfg.ConfigLocation, "system.nix"), "", true
+		} else {
+			return cfg.ConfigLocation, "", true
+		}
+	} else {
+		log.Warn(err)
+	}
+
+	return "", "", false
+}
+
+func findImplicitConfiguration(
+	log logger.Logger,
+	includes []string,
+	nixPath map[string]string,
+) (string, bool) {
+	if config, set := os.LookupEnv("NIXOS_CONFIG"); set {
+		log.Debug("$NIXOS_CONFIG is set, using automatically")
+		return config, true
+	}
+
+	log.Debug("looking for nixos-config= entry in includes list")
+
+	for _, include := range includes {
+		if config, ok := strings.CutPrefix(include, "nixos-config="); ok {
+			log.Debug("found nixos-config= in include list")
+			return config, true
 		}
 	}
 
-	if configPath == "" {
-		log.Debugf("no 'nixos-config' attribute exists in NIX_PATH")
-		return nil, fmt.Errorf("no configuration found")
+	log.Debug("looking for nixos-config= entry in $NIX_PATH")
+
+	if config, ok := nixPath["nixos-config"]; ok {
+		log.Debug("found nixos-config entry in $NIX_PATH")
+		return config, true
 	}
 
-	resolvedPath, err := utils.ResolveNixFilename(configPath)
-	if err != nil {
-		return nil, err
+	return "", false
+}
+
+func getNixPathEntries() map[string]string {
+	entries := make(map[string]string)
+
+	nixPath := strings.SplitSeq(os.Getenv("NIX_PATH"), ":")
+	for entry := range nixPath {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		entries[key] = value
+
 	}
 
-	return &LegacyConfiguration{
-		Includes:   includes,
-		ConfigPath: resolvedPath,
-	}, nil
+	return entries
 }
 
 // Get the directory that this configuration file is found in
@@ -186,9 +278,9 @@ func (l *LegacyConfiguration) buildLocalSystem(s *system.LocalSystem, buildType 
 
 	log := s.Logger()
 
-	if log.GetLogLevel() == logger.LogLevelDebug {
-		argv = append(argv, "-v")
-	}
+	// if log.GetLogLevel() == logger.LogLevelDebug {
+	// 	argv = append(argv, "-v")
+	// }
 
 	log.CmdArray(argv)
 

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -293,7 +293,9 @@ var SettingsDocs = map[string]SettingsDocEntry{
 	},
 	"config_location": {
 		Short: "Where to look for configuration by default",
-		Long:  "Path to a Nix file or directory to look for user configuration in by default.",
+		Long: "Path to a Nix file or directory to look for user configuration in by default." +
+			" If this is a directory, then nixos-cli will search for a system.nix file or flake ref here." +
+			" If it is a file, then it will be used as an explicit configuration in legacy mode only.",
 	},
 	"confirmation": {
 		Short: "Settings for confirmation prompts throughout the program",

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -206,3 +206,21 @@ func GetUsername() (string, error) {
 		return "", fmt.Errorf("failed to determine current user")
 	}
 }
+
+// Find if a directory contains a file.
+func ContainsFile(dir string, filename string) bool {
+	s, err := os.Stat(dir)
+	if err != nil {
+		return false
+	}
+
+	if !s.IsDir() {
+		return false
+	}
+
+	if _, err = os.Stat(filepath.Join(dir, filename)); err != nil {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
Legacy configurations support the new `system.nix` entrypoint in https://github.com/NixOS/nixpkgs/pull/493229.

This PR adds support for this alternative entrypoint to the `apply`, `repl`, `option`, and `install` subcommands and also clarifies order of legacy configuration discovery. Explicit configurations now are always discovered first, and implicit ones afterwards.

The configuration discovery mechanism has also been split into a separate man page, rather than being embedded in `nixos-cli-env(5)`.

Closes #221.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer configuration discovery for legacy workflows, including support for explicit system configuration selection and directory-based config resolution.
  * Introduced new documentation explaining how configuration files, environment variables, and system paths are interpreted.

* **Documentation**
  * Updated CLI man pages with clearer examples, argument descriptions, and cross-references.
  * Added guidance for environment variables and configuration lookup behavior.

* **Bug Fixes**
  * Improved how `apply`, `install`, `option`, and `repl` resolve legacy configuration paths.
  * Refined legacy install behavior so include flags are only added when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->